### PR TITLE
Refactor querystring generation to fix two bugs surrounding returnBody and false valued querystring variables

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,36 +1,38 @@
-var Client, CoreMeta;
-var __bind = function(func, context) {
+(function() {
+  var Client, CoreMeta;
+  var __bind = function(func, context) {
     return function(){ return func.apply(context, arguments); };
   };
-CoreMeta = require('./meta');
-Client = function() {};
-Client.prototype.executeCallback = function(data, meta, callback) {
-  var err;
-  callback || (callback = __bind(function(err, data, meta) {
-    return this.log(data, {
-      json: this.contentType === 'json'
-    });
-  }, this));
-  err = null;
-  if (data instanceof Error) {
-    err = data;
-    data = data.message;
-  }
-  return callback(err, data, meta);
-};
-Client.prototype.ensure = function(options) {
-  var _ref, callback;
-  _ref = options;
-  options = _ref[0];
-  callback = _ref[1];
-  if (typeof options === 'function') {
-    callback = options;
-    options = undefined;
-  }
-  return [options || {}, callback];
-};
-Client.prototype.log = function(string, options) {
-  options || (options = {});
-  return string && console && (options.debug !== undefined ? options.debug : CoreMeta.defaults.debug) ? (options.json ? console.dir(string) : console.log(string)) : null;
-};
-module.exports = Client;
+  CoreMeta = require('./meta');
+  Client = function() {};
+  Client.prototype.executeCallback = function(data, meta, callback) {
+    var err;
+    callback || (callback = __bind(function(err, data, meta) {
+      return this.log(data, {
+        json: this.contentType === 'json'
+      });
+    }, this));
+    err = null;
+    if (data instanceof Error) {
+      err = data;
+      data = data.message;
+    }
+    return callback(err, data, meta);
+  };
+  Client.prototype.ensure = function(options) {
+    var _a, callback;
+    _a = options;
+    options = _a[0];
+    callback = _a[1];
+    if (typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    return [options || {}, callback];
+  };
+  Client.prototype.log = function(string, options) {
+    options || (options = {});
+    return string && console && (options.debug !== undefined ? options.debug : CoreMeta.defaults.debug) ? (options.json ? console.dir(string) : console.log(string)) : null;
+  };
+  module.exports = Client;
+})();

--- a/lib/http_client.js
+++ b/lib/http_client.js
@@ -1,389 +1,366 @@
-var Client, CoreMeta, Http, HttpClient, Link, Mapper, Meta, Utils, querystring;
-var __slice = Array.prototype.slice, __bind = function(func, context) {
+(function() {
+  var Client, CoreMeta, Http, HttpClient, Link, Mapper, Meta, Utils;
+  var __slice = Array.prototype.slice, __bind = function(func, context) {
     return function(){ return func.apply(context, arguments); };
-  }, __hasProp = Object.prototype.hasOwnProperty, __extends = function(child, parent) {
+  }, __extends = function(child, parent) {
     var ctor = function(){};
     ctor.prototype = parent.prototype;
     child.prototype = new ctor();
     child.prototype.constructor = child;
     if (typeof parent.extended === "function") parent.extended(child);
     child.__super__ = parent.prototype;
+  }, __hasProp = Object.prototype.hasOwnProperty;
+  Client = require('./client');
+  CoreMeta = require('./meta');
+  Mapper = require('./mapper');
+  Utils = require('./utils');
+  Http = require('http');
+  HttpClient = function(options) {
+    var _a, host, port;
+    _a = ['localhost', 8098];
+    host = _a[0];
+    port = _a[1];
+    CoreMeta.defaults = Utils.mixin(true, CoreMeta.defaults, options);
+    this.client = Http.createClient(((typeof options === "undefined" || options === null) ? undefined : options.port) || port, ((typeof options === "undefined" || options === null) ? undefined : options.host) || host);
+    return this;
   };
-Client = require('./client');
-CoreMeta = require('./meta');
-Mapper = require('./mapper');
-Utils = require('./utils');
-Http = require('http');
-querystring = require('querystring');
-HttpClient = function(options) {
-  var _ref, host, port;
-  _ref = ['localhost', 8098];
-  host = _ref[0];
-  port = _ref[1];
-  CoreMeta.defaults = Utils.mixin(true, CoreMeta.defaults, options);
-  this.client = Http.createClient(((typeof options === "undefined" || options === null) ? undefined : options.port) || port, ((typeof options === "undefined" || options === null) ? undefined : options.host) || host);
-  return this;
-};
-__extends(HttpClient, Client);
-HttpClient.prototype.get = function(bucket, key) {
-  var _ref, callback, meta, options;
-  options = __slice.call(arguments, 2);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  meta = new Meta(bucket, key, options);
-  return this.execute('GET', meta)(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-HttpClient.prototype.head = function(bucket, key) {
-  var _ref, callback, meta, options;
-  options = __slice.call(arguments, 2);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  meta = new Meta(bucket, key, options);
-  return this.execute('HEAD', meta)(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-HttpClient.prototype.getAll = function(bucket) {
-  var _ref, callback, mapfunc, options;
-  options = __slice.call(arguments, 1);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  mapfunc = function(v, k, options) {
-    var data, keys;
-    data = options.noJSON ? Riak.mapValues(v)[0] : Riak.mapValuesJson(v)[0];
-    if (options.where && !options.noJSON) {
-      keys = [];
-      for (var i in options.where) keys.push(i);
-      if (keys.some(function(k) {
-        return options.where[k] !== data[k];
-      })) {
-        return [];
-      }
-    }
-    delete v.values;
-    return [
-      {
-        meta: v,
-        data: data
-      }
-    ];
-  };
-  return this.add(bucket).map(mapfunc, options).run(callback);
-};
-HttpClient.prototype.keys = function(bucket) {
-  var _ref, callback, meta, options;
-  options = __slice.call(arguments, 1);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  options.keys = true;
-  meta = new Meta(bucket, '', options);
-  return this.execute('GET', meta)(__bind(function(data, meta) {
-    return this.executeCallback(data.keys, meta, callback);
-  }, this));
-};
-HttpClient.prototype.count = function(bucket) {
-  var _ref, callback, options;
-  options = __slice.call(arguments, 1);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  return this.add(bucket).map(function(v) {
-    return [1];
-  }).reduce(['Riak.filterNotFound', 'Riak.reduceSum']).run(callback);
-};
-HttpClient.prototype.walk = function(bucket, key, spec) {
-  var _ref, callback, linkPhases, options;
-  options = __slice.call(arguments, 3);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  linkPhases = spec.map(function(unit) {
-    return {
-      bucket: unit[0] || '_',
-      tag: unit[1] || '_',
-      keep: !!unit[2]
-    };
-  });
-  return this.link(linkPhases).reduce({
-    language: 'erlang',
-    module: 'riak_kv_mapreduce',
-    "function": 'reduce_set_union'
-  }).map('Riak.mapValuesJson').run(key ? [[bucket, key]] : bucket, options, callback);
-};
-HttpClient.prototype.save = function(bucket, key, data) {
-  var _ref, callback, meta, options, verb;
-  options = __slice.call(arguments, 3);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  data || (data = {});
-  meta = new Meta(bucket, key, options);
-  meta.data = data;
-  verb = options.method || (key ? 'PUT' : 'POST');
-  return this.execute(verb, meta)(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-HttpClient.prototype.remove = function(bucket, key) {
-  var _ref, callback, meta, options;
-  options = __slice.call(arguments, 2);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  meta = new Meta(bucket, key, options);
-  return this.execute('DELETE', meta)(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-HttpClient.prototype.add = function(inputs) {
-  return new Mapper(this, inputs);
-};
-HttpClient.prototype.runJob = function(options, callback) {
-  options.raw = 'mapred';
-  return this.save('', '', options.data, options, callback);
-};
-HttpClient.prototype.end = function() {};
-HttpClient.prototype.getProps = function(bucket) {
-  var _ref, callback, options;
-  options = __slice.call(arguments, 1);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  return this.get(bucket, undefined, options, callback);
-};
-HttpClient.prototype.updateProps = function(bucket, props) {
-  var _ref, callback, options;
-  options = __slice.call(arguments, 2);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  options.method = 'PUT';
-  return this.save(bucket, undefined, {
-    props: props
-  }, options, callback);
-};
-HttpClient.prototype.ping = function(callback) {
-  var meta;
-  meta = new Meta('', '', {
-    raw: 'ping'
-  });
-  return this.execute('HEAD', meta)(__bind(function(data, meta) {
-    return this.executeCallback(true, meta, callback);
-  }, this));
-};
-HttpClient.prototype.stats = function(callback) {
-  var meta;
-  meta = new Meta('', '', {
-    raw: 'stats'
-  });
-  return this.execute('GET', meta)(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-HttpClient.prototype.execute = function(verb, meta) {
-  return __bind(function(callback) {
-    var buffer, cbFired, headers, onClose, path, query, queryProps, request, url, val;
-    url = ("/" + (meta.raw) + "/" + (meta.bucket) + "/" + (meta.key || ''));
-    verb = verb.toUpperCase();
-    queryProps = {};
-    ['r', 'w', 'dw', 'keys', 'props', 'vtag', 'nocache', 'returnbody'].forEach(function(prop) {
-      if (meta[prop] !== undefined) {
-        return (queryProps[prop] = meta[prop]);
-      }
-    });
-    query = this.stringifyQuery(queryProps);
-    path = ("" + (url) + (query ? '?' + query : ''));
-    if (meta.data) {
-      val = meta.encode(meta.data);
-    }
-    headers = meta.toHeaders();
-    this.log("" + (verb) + " " + (path));
-    request = this.client.request(verb, path, headers);
-    cbFired = false;
-    onClose = __bind(function(hadError, reason) {
-      if (hadError && !cbFired) {
-        callback(new Error(reason));
-      }
-      return this.client.removeListener('close', onClose);
-    }, this);
-    this.client.on('close', onClose);
-    this.client.on('error', function(err) {
-      return onClose(true, err);
-    });
-    if (meta.data) {
-      request.write(val, meta.contentEncoding);
-      delete meta.data;
-    }
-    buffer = '';
-    request.on('response', __bind(function(response) {
-      response.setEncoding(meta.usermeta.responseEncoding || 'utf8');
-      response.on('data', function(chunk) {
-        return buffer += chunk;
-      });
-      return response.on('end', __bind(function() {
-        var boundary, err;
-        meta = meta.loadHeaders(response.headers, response.statusCode);
-        buffer = (function() {
-          if ((400 <= meta.statusCode) && (meta.statusCode < 600)) {
-            err = new Error(buffer);
-            if (meta.statusCode === 404) {
-              err.message = undefined;
-            }
-            err.statusCode = meta.statusCode;
-            return err;
-          } else {
-            return this.decodeBuffer(buffer, meta);
-          }
-        }).call(this);
-        if (meta.statusCode === 300 && meta.contentType.match(/^multipart\/mixed/)) {
-          boundary = Utils.extractBoundary(meta.contentType);
-          buffer = Utils.parseMultipart(buffer, boundary).map(__bind(function(doc) {
-            var _meta;
-            _meta = new Meta(meta.bucket, meta.key);
-            _meta.loadHeaders(doc.headers);
-            _meta.vclock = meta.vclock;
-            return {
-              meta: _meta,
-              data: this.decodeBuffer(doc.body, _meta)
-            };
-          }, this));
-        }
-        cbFired = true;
-        return callback(buffer, meta);
-      }, this));
+  __extends(HttpClient, Client);
+  HttpClient.prototype.get = function(bucket, key) {
+    var _a, callback, meta, options;
+    options = __slice.call(arguments, 2);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    meta = new Meta(bucket, key, options);
+    return this.execute('GET', meta)(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
     }, this));
-    return request.end();
-  }, this);
-};
-HttpClient.prototype.stringifyQuery = function(query) {
-  var _ref, key, value;
-  _ref = query;
-  for (key in _ref) {
-    if (!__hasProp.call(_ref, key)) continue;
-    value = _ref[key];
-    if (typeof value === 'boolean') {
-      query[key] = String(value);
-    }
-  }
-  return querystring.stringify(query);
-};
-HttpClient.prototype.decodeBuffer = function(buffer, meta) {
-  if (meta.contentType === 'application/octet-stream') {
-    return new Buffer(buffer, 'binary');
-  } else {
-    try {
-      return buffer.length > 0 ? meta.decode(buffer) : undefined;
-    } catch (e) {
-      return new Error("Cannot convert response into " + (meta.contentType) + ": " + (e.message) + " -- Response: " + (buffer));
-    }
-  }
-};
-Meta = function() {
-  return CoreMeta.apply(this, arguments);
-};
-__extends(Meta, CoreMeta);
-Meta.prototype.mappings = {
-  contentType: 'content-type',
-  vclock: 'x-riak-vclock',
-  lastMod: 'last-modified',
-  etag: 'etag',
-  links: 'link',
-  host: 'host',
-  clientId: 'x-riak-clientid'
-};
-Meta.prototype.loadHeaders = function(headers, statusCode) {
-  var _ref, k, options, u, v;
-  options = {};
-  _ref = this.mappings;
-  for (k in _ref) {
-    if (!__hasProp.call(_ref, k)) continue;
-    v = _ref[k];
-    if (v === 'link') {
-      options[k] = this.stringToLinks(headers[v]);
-    } else {
-      options[k] = headers[v];
-    }
-  }
-  _ref = headers;
-  for (k in _ref) {
-    if (!__hasProp.call(_ref, k)) continue;
-    v = _ref[k];
-    u = k.match(/^X-Riak-Meta-(.*)/i);
-    if (u) {
-      this.usermeta[u[1]] = v;
-    }
-  }
-  this.load(Utils.mixin(true, this.usermeta, options));
-  this.statusCode = statusCode;
-  return this;
-};
-Meta.prototype.toHeaders = function() {
-  var _ref, headers, k, v;
-  headers = {
-    Accept: "multipart/mixed, application/json;q=0.7, */*;q=0.5"
   };
-  _ref = this.mappings;
-  for (k in _ref) {
-    if (!__hasProp.call(_ref, k)) continue;
-    v = _ref[k];
-    if (k === 'links') {
-      headers[v] = this.linksToString();
+  HttpClient.prototype.head = function(bucket, key) {
+    var _a, callback, meta, options;
+    options = __slice.call(arguments, 2);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    meta = new Meta(bucket, key, options);
+    return this.execute('HEAD', meta)(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
+    }, this));
+  };
+  HttpClient.prototype.getAll = function(bucket) {
+    var _a, callback, mapfunc, options;
+    options = __slice.call(arguments, 1);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    mapfunc = function(v, k, options) {
+      var data, keys;
+      data = options.noJSON ? Riak.mapValues(v)[0] : Riak.mapValuesJson(v)[0];
+      if (options.where && !options.noJSON) {
+        keys = [];
+        for (var i in options.where) keys.push(i);
+        if (keys.some(function(k) {
+          return options.where[k] !== data[k];
+        })) {
+          return [];
+        }
+      }
+      delete v.values;
+      return [
+        {
+          meta: v,
+          data: data
+        }
+      ];
+    };
+    return this.add(bucket).map(mapfunc, options).run(callback);
+  };
+  HttpClient.prototype.keys = function(bucket) {
+    var _a, callback, meta, options;
+    options = __slice.call(arguments, 1);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    options.keys = true;
+    meta = new Meta(bucket, '', options);
+    return this.execute('GET', meta)(__bind(function(data, meta) {
+      return this.executeCallback(data.keys, meta, callback);
+    }, this));
+  };
+  HttpClient.prototype.count = function(bucket) {
+    var _a, callback, options;
+    options = __slice.call(arguments, 1);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    return this.add(bucket).map(function(v) {
+      return [1];
+    }).reduce(['Riak.filterNotFound', 'Riak.reduceSum']).run(callback);
+  };
+  HttpClient.prototype.walk = function(bucket, key, spec) {
+    var _a, callback, linkPhases, options;
+    options = __slice.call(arguments, 3);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    linkPhases = spec.map(function(unit) {
+      return {
+        bucket: unit[0] || '_',
+        tag: unit[1] || '_',
+        keep: !!unit[2]
+      };
+    });
+    return this.link(linkPhases).reduce({
+      language: 'erlang',
+      module: 'riak_kv_mapreduce',
+      "function": 'reduce_set_union'
+    }).map('Riak.mapValuesJson').run(key ? [[bucket, key]] : bucket, options, callback);
+  };
+  HttpClient.prototype.save = function(bucket, key, data) {
+    var _a, callback, meta, options, verb;
+    options = __slice.call(arguments, 3);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    data || (data = {});
+    meta = new Meta(bucket, key, options);
+    meta.data = data;
+    verb = options.method || (key ? 'PUT' : 'POST');
+    return this.execute(verb, meta)(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
+    }, this));
+  };
+  HttpClient.prototype.remove = function(bucket, key) {
+    var _a, callback, meta, options;
+    options = __slice.call(arguments, 2);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    meta = new Meta(bucket, key, options);
+    return this.execute('DELETE', meta)(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
+    }, this));
+  };
+  HttpClient.prototype.add = function(inputs) {
+    return new Mapper(this, inputs);
+  };
+  HttpClient.prototype.runJob = function(options, callback) {
+    options.raw = 'mapred';
+    return this.save('', '', options.data, options, callback);
+  };
+  HttpClient.prototype.end = function() {};
+  HttpClient.prototype.getProps = function(bucket) {
+    var _a, callback, options;
+    options = __slice.call(arguments, 1);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    return this.get(bucket, undefined, options, callback);
+  };
+  HttpClient.prototype.updateProps = function(bucket, props) {
+    var _a, callback, options;
+    options = __slice.call(arguments, 2);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    options.method = 'PUT';
+    return this.save(bucket, undefined, {
+      props: props
+    }, options, callback);
+  };
+  HttpClient.prototype.ping = function(callback) {
+    var meta;
+    meta = new Meta('', '', {
+      raw: 'ping'
+    });
+    return this.execute('HEAD', meta)(__bind(function(data, meta) {
+      return this.executeCallback(true, meta, callback);
+    }, this));
+  };
+  HttpClient.prototype.stats = function(callback) {
+    var meta;
+    meta = new Meta('', '', {
+      raw: 'stats'
+    });
+    return this.execute('GET', meta)(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
+    }, this));
+  };
+  HttpClient.prototype.execute = function(verb, meta) {
+    return __bind(function(callback) {
+      var buffer, cbFired, onClose, path, request;
+      verb = verb.toUpperCase();
+      path = meta.path;
+      this.log("" + (verb) + " " + (path));
+      request = this.client.request(verb, path, meta.toHeaders());
+      if (meta.data) {
+        request.write(meta.encodeData(), meta.contentEncoding);
+        delete meta.data;
+      }
+      cbFired = false;
+      onClose = __bind(function(hadError, reason) {
+        if (hadError && !cbFired) {
+          callback(new Error(reason));
+        }
+        return this.client.removeListener('close', onClose);
+      }, this);
+      this.client.on('close', onClose);
+      this.client.on('error', function(err) {
+        return onClose(true, err);
+      });
+      buffer = '';
+      request.on('response', __bind(function(response) {
+        response.setEncoding(meta.usermeta.responseEncoding || 'utf8');
+        response.on('data', function(chunk) {
+          return buffer += chunk;
+        });
+        return response.on('end', __bind(function() {
+          var boundary, err;
+          meta = meta.loadHeaders(response.headers, response.statusCode);
+          buffer = (function() {
+            if ((400 <= meta.statusCode) && (meta.statusCode < 600)) {
+              err = new Error(buffer);
+              if (meta.statusCode === 404) {
+                err.message = undefined;
+              }
+              err.statusCode = meta.statusCode;
+              return err;
+            } else {
+              return this.decodeBuffer(buffer, meta);
+            }
+          }).call(this);
+          if (meta.statusCode === 300 && meta.contentType.match(/^multipart\/mixed/)) {
+            boundary = Utils.extractBoundary(meta.contentType);
+            buffer = Utils.parseMultipart(buffer, boundary).map(__bind(function(doc) {
+              var _meta;
+              _meta = new Meta(meta.bucket, meta.key);
+              _meta.loadHeaders(doc.headers);
+              _meta.vclock = meta.vclock;
+              return {
+                meta: _meta,
+                data: this.decodeBuffer(doc.body, _meta)
+              };
+            }, this));
+          }
+          cbFired = true;
+          return callback(buffer, meta);
+        }, this));
+      }, this));
+      return request.end();
+    }, this);
+  };
+  HttpClient.prototype.decodeBuffer = function(buffer, meta) {
+    if (meta.contentType === 'application/octet-stream') {
+      return new Buffer(buffer, 'binary');
     } else {
-      if (this[k]) {
-        headers[v] = this[k];
+      try {
+        return buffer.length > 0 ? meta.decode(buffer) : undefined;
+      } catch (e) {
+        return new Error("Cannot convert response into " + (meta.contentType) + ": " + (e.message) + " -- Response: " + (buffer));
       }
     }
-  }
-  _ref = this.usermeta;
-  for (k in _ref) {
-    if (!__hasProp.call(_ref, k)) continue;
-    v = _ref[k];
-    headers[("X-Riak-Meta-" + (k))] = v;
-  }
-  if (this.etag) {
-    headers['If-None-Match'] = this.etag;
-  }
-  return headers;
-};
-Meta.prototype.stringToLinks = function(links) {
-  var result;
-  result = [];
-  if (links) {
-    links.split(',').forEach(function(link) {
-      var _i, _ref, captures, i;
-      captures = link.trim().match(/^<\/(.*)\/(.*)\/(.*)>;\sriaktag="(.*)"$/);
-      if (captures) {
-        _ref = captures;
-        for (i in _ref) {
-          if (!__hasProp.call(_ref, i)) continue;
-          _i = _ref[i];
-          captures[i] = decodeURIComponent(captures[i]);
-        }
-        return result.push(new Link({
-          bucket: captures[2],
-          key: captures[3],
-          tag: captures[4]
-        }));
+  };
+  Meta = function() {
+    return CoreMeta.apply(this, arguments);
+  };
+  __extends(Meta, CoreMeta);
+  Meta.prototype.mappings = {
+    contentType: 'content-type',
+    vclock: 'x-riak-vclock',
+    lastMod: 'last-modified',
+    etag: 'etag',
+    links: 'link',
+    host: 'host',
+    clientId: 'x-riak-clientid'
+  };
+  Meta.prototype.loadHeaders = function(headers, statusCode) {
+    var _a, _b, k, options, u, v;
+    options = {};
+    _a = this.mappings;
+    for (k in _a) {
+      if (!__hasProp.call(_a, k)) continue;
+      v = _a[k];
+      if (v === 'link') {
+        options[k] = this.stringToLinks(headers[v]);
+      } else {
+        options[k] = headers[v];
       }
-    });
-  }
-  return result;
-};
-Meta.prototype.linksToString = function() {
-  return this.links.map(__bind(function(link) {
-    return "</" + (this.raw) + "/" + (link.bucket) + "/" + (link.key) + ">; riaktag=\"" + (link.tag || "_") + "\"";
-  }, this)).join(", ");
-};
-Link = function(options) {
-  this.bucket = options.bucket;
-  this.key = options.key;
-  this.tag = options.tag;
-  return this;
-};
-module.exports = HttpClient;
+    }
+    _b = headers;
+    for (k in _b) {
+      if (!__hasProp.call(_b, k)) continue;
+      v = _b[k];
+      u = k.match(/^X-Riak-Meta-(.*)/i);
+      if (u) {
+        this.usermeta[u[1]] = v;
+      }
+    }
+    this.load(Utils.mixin(true, this.usermeta, options));
+    this.statusCode = statusCode;
+    return this;
+  };
+  Meta.prototype.toHeaders = function() {
+    var _a, _b, headers, k, v;
+    headers = {
+      Accept: "multipart/mixed, application/json;q=0.7, */*;q=0.5"
+    };
+    _a = this.mappings;
+    for (k in _a) {
+      if (!__hasProp.call(_a, k)) continue;
+      v = _a[k];
+      if (k === 'links') {
+        headers[v] = this.linksToString();
+      } else {
+        if (this[k]) {
+          headers[v] = this[k];
+        }
+      }
+    }
+    _b = this.usermeta;
+    for (k in _b) {
+      if (!__hasProp.call(_b, k)) continue;
+      v = _b[k];
+      headers[("X-Riak-Meta-" + (k))] = v;
+    }
+    if (this.etag) {
+      headers['If-None-Match'] = this.etag;
+    }
+    return headers;
+  };
+  Meta.prototype.stringToLinks = function(links) {
+    var result;
+    result = [];
+    if (links) {
+      links.split(',').forEach(function(link) {
+        var _a, _b, captures, i;
+        captures = link.trim().match(/^<\/(.*)\/(.*)\/(.*)>;\sriaktag="(.*)"$/);
+        if (captures) {
+          _b = captures;
+          for (i in _b) {
+            if (!__hasProp.call(_b, i)) continue;
+            _a = _b[i];
+            captures[i] = decodeURIComponent(captures[i]);
+          }
+          return result.push(new Link({
+            bucket: captures[2],
+            key: captures[3],
+            tag: captures[4]
+          }));
+        }
+      });
+    }
+    return result;
+  };
+  Meta.prototype.linksToString = function() {
+    return this.links.map(__bind(function(link) {
+      return "</" + (this.raw) + "/" + (link.bucket) + "/" + (link.key) + ">; riaktag=\"" + (link.tag || "_") + "\"";
+    }, this)).join(", ");
+  };
+  Link = function(options) {
+    this.bucket = options.bucket;
+    this.key = options.key;
+    this.tag = options.tag;
+    return this;
+  };
+  module.exports = HttpClient;
+})();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,32 +1,34 @@
-module.exports = {
-  http: function(options) {
-    return new this.HttpClient(options);
-  },
-  protobuf: function(options) {
-    var cli, pool;
-    options || (options = {});
-    pool = options.pool;
-    delete options.pool;
-    pool || (pool = new this.ProtoBufPool(options));
-    cli = new this.ProtoBufClient(options);
-    cli.pool = pool;
-    return cli;
-  },
-  defaults: {
-    api: 'http'
-  },
-  getClient: function(options) {
-    options || (options = {});
-    options.api || (options.api = module.exports.defaults.api);
-    return this[options.api](options);
-  }
-};
-module.exports.__defineGetter__('ProtoBufClient', function() {
-  return this._pbcClient || (this._pbcClient = require('./protobuf_client'));
-});
-module.exports.__defineGetter__('ProtoBufPool', function() {
-  return this._pbcPool || (this._pbcPool = require('./protobuf'));
-});
-module.exports.__defineGetter__('HttpClient', function() {
-  return this._httpClient || (this._httpClient = require('./http_client'));
-});
+(function() {
+  module.exports = {
+    http: function(options) {
+      return new this.HttpClient(options);
+    },
+    protobuf: function(options) {
+      var cli, pool;
+      options || (options = {});
+      pool = options.pool;
+      delete options.pool;
+      pool || (pool = new this.ProtoBufPool(options));
+      cli = new this.ProtoBufClient(options);
+      cli.pool = pool;
+      return cli;
+    },
+    defaults: {
+      api: 'http'
+    },
+    getClient: function(options) {
+      options || (options = {});
+      options.api || (options.api = module.exports.defaults.api);
+      return this[options.api](options);
+    }
+  };
+  module.exports.__defineGetter__('ProtoBufClient', function() {
+    return this._pbcClient || (this._pbcClient = require('./protobuf_client'));
+  });
+  module.exports.__defineGetter__('ProtoBufPool', function() {
+    return this._pbcPool || (this._pbcPool = require('./protobuf'));
+  });
+  module.exports.__defineGetter__('HttpClient', function() {
+    return this._httpClient || (this._httpClient = require('./http_client'));
+  });
+})();

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -1,49 +1,50 @@
-var Mapper, utils;
-var __slice = Array.prototype.slice, __bind = function(func, context) {
+(function() {
+  var Mapper, utils;
+  var __slice = Array.prototype.slice, __bind = function(func, context) {
     return function(){ return func.apply(context, arguments); };
   };
-utils = require('./utils');
-Mapper = function(_arg, _arg2) {
-  this.inputs = _arg2;
-  this.riak = _arg;
-  this.phases = [];
-  return this;
-};
-Mapper.prototype.map = function(phase, args) {
-  return this.makePhases("map", phase, args);
-};
-Mapper.prototype.reduce = function(phase, args) {
-  return this.makePhases("reduce", phase, args);
-};
-Mapper.prototype.link = function(phase) {
-  return this.makePhases("link", phase);
-};
-Mapper.prototype.run = function() {
-  var _ref, callback, options;
-  options = __slice.call(arguments, 0);
-  _ref = this.riak.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  return this.riak.runJob(this.job(this.inputs, options), callback);
-};
-Mapper.prototype.job = function(inputs, options) {
-  options || (options = {});
-  options.data = {
-    inputs: inputs,
-    query: this.phases
+  utils = require('./utils');
+  Mapper = function(_a, _b) {
+    this.inputs = _b;
+    this.riak = _a;
+    this.phases = [];
+    return this;
   };
-  return options;
-};
-Mapper.prototype.makePhases = function(type, phase, args) {
-  if (!utils.isArray(phase)) {
-    phase = [phase];
-  }
-  phase.forEach(__bind(function(p) {
-    var _ref, temp;
-    temp = {};
-    if (p) {
-      temp[type] = (function() {
-        switch (typeof p) {
+  Mapper.prototype.map = function(phase, args) {
+    return this.makePhases("map", phase, args);
+  };
+  Mapper.prototype.reduce = function(phase, args) {
+    return this.makePhases("reduce", phase, args);
+  };
+  Mapper.prototype.link = function(phase) {
+    return this.makePhases("link", phase);
+  };
+  Mapper.prototype.run = function() {
+    var _a, callback, options;
+    options = __slice.call(arguments, 0);
+    _a = this.riak.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    return this.riak.runJob(this.job(this.inputs, options), callback);
+  };
+  Mapper.prototype.job = function(inputs, options) {
+    options || (options = {});
+    options.data = {
+      inputs: inputs,
+      query: this.phases
+    };
+    return options;
+  };
+  Mapper.prototype.makePhases = function(type, phase, args) {
+    if (!utils.isArray(phase)) {
+      phase = [phase];
+    }
+    phase.forEach(__bind(function(p) {
+      var _a, temp;
+      temp = {};
+      if (p) {
+        temp[type] = (function() {
+          switch (typeof p) {
           case 'function':
             return {
               source: p.toString(),
@@ -55,19 +56,20 @@ Mapper.prototype.makePhases = function(type, phase, args) {
               arg: args
             };
           case 'object':
-            if (typeof (_ref = p.source) !== "undefined" && _ref !== null) {
+            if (typeof (_a = p.source) !== "undefined" && _a !== null) {
               p.source = p.source.toString();
             }
             return p;
-        }
-      })();
-      temp[type].language || (temp[type].language = Mapper.defaults.language);
-      return this.phases.push(temp);
-    }
-  }, this));
-  return this;
-};
-Mapper.defaults = {
-  language: 'javascript'
-};
-module.exports = Mapper;
+          }
+        })();
+        temp[type].language || (temp[type].language = Mapper.defaults.language);
+        return this.phases.push(temp);
+      }
+    }, this));
+    return this;
+  };
+  Mapper.defaults = {
+    language: 'javascript'
+  };
+  module.exports = Mapper;
+})();

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -1,44 +1,61 @@
-var Meta, Utils;
-var __bind = function(func, context) {
+(function() {
+  var Meta, Utils, querystring;
+  var __bind = function(func, context) {
     return function(){ return func.apply(context, arguments); };
+  }, __hasProp = Object.prototype.hasOwnProperty;
+  Utils = require('./utils');
+  querystring = require('querystring');
+  Meta = function(bucket, key, options, data) {
+    this.bucket = bucket;
+    this.key = key;
+    this.load(options);
+    return this;
   };
-Utils = require('./utils');
-Meta = function(bucket, key, options, data) {
-  this.bucket = bucket;
-  this.key = key;
-  this.load(options);
-  return this;
-};
-Meta.prototype.decode = function(value) {
-  var dec;
-  return (dec = Meta.decoders[this.contentType]) ? dec(value) : value;
-};
-Meta.prototype.encode = function(value) {
-  var dec;
-  if (value instanceof Buffer) {
-    this.contentEncoding = 'binary';
-    this.contentType = this.guessType(this.contentEncoding);
-    return value;
-  }
-  return (dec = Meta.encoders[this.contentType]) ? dec(value) : value.toString();
-};
-Meta.prototype.load = function(options) {
-  this.usermeta = Utils.mixin(true, this.defaults, options);
-  return Meta.riakProperties.forEach(__bind(function(key) {
-    var value;
-    value = this.popKey(key) || Meta.defaults[key];
-    if (value) {
-      if (key === 'links' && !Utils.isArray(value)) {
-        value = [value];
-      }
-      return (this[key] = value);
-    } else {
-      return delete this[key];
+  Meta.prototype.decode = function(value) {
+    var dec;
+    return (dec = Meta.decoders[this.contentType]) ? dec(value) : value;
+  };
+  Meta.prototype.encode = function(value) {
+    var dec;
+    if (value instanceof Buffer) {
+      this.contentEncoding = 'binary';
+      this.contentType = this.guessType(this.contentEncoding);
+      return value;
     }
-  }, this));
-};
-Meta.prototype.guessType = function(type) {
-  switch (type) {
+    return (dec = Meta.encoders[this.contentType]) ? dec(value) : value.toString();
+  };
+  Meta.prototype.load = function(options) {
+    this.usermeta = Utils.mixin(true, this.defaults, options);
+    Meta.riakProperties.forEach(__bind(function(key) {
+      var value;
+      value = this.popKey(key);
+      if (value === undefined) {
+        value = Meta.defaults[key];
+      }
+      if (value !== undefined) {
+        if (key === 'links' && !Utils.isArray(value)) {
+          value = [value];
+        }
+        return (this[key] = value);
+      } else {
+        return delete this[key];
+      }
+    }, this));
+    this.url = ("/" + (this.raw) + "/" + (this.bucket) + "/" + (this.key || ''));
+    this.queryProps = {};
+    Meta.queryProperties.forEach(__bind(function(prop) {
+      if (this[prop] !== undefined) {
+        return (this.queryProps[prop] = this[prop]);
+      }
+    }, this));
+    this.queryString = this.stringifyQuery(this.queryProps);
+    return (this.path = ("" + (this.url) + (this.queryString ? '?' + this.queryString : '')));
+  };
+  Meta.prototype.encodeData = function() {
+    return this.encode(this.data);
+  };
+  Meta.prototype.guessType = function(type) {
+    switch (type) {
     case 'json':
       return 'application/json';
     case 'xml':
@@ -52,43 +69,57 @@ Meta.prototype.guessType = function(type) {
       return 'application/octet-stream';
     default:
       return type;
-  }
-};
-Meta.prototype.popKey = function(key) {
-  var value;
-  value = this.usermeta[key];
-  delete this.usermeta[key];
-  return value;
-};
-Meta.riakProperties = ['contentType', 'vclock', 'lastMod', 'lastModUsecs', 'vtag', 'charset', 'contentEncoding', 'statusCode', 'links', 'etag', 'r', 'w', 'dw', 'returnBody', 'rw', 'raw', 'keys', 'nocache', 'clientId', 'data', 'host'];
-Meta.defaults = {
-  links: [],
-  contentType: 'json',
-  raw: 'riak',
-  clientId: 'riak-js',
-  debug: true,
-  host: 'localhost'
-};
-Meta.decoders = {
-  "application/json": function(s) {
-    return JSON.parse(s);
-  }
-};
-Meta.encoders = {
-  "application/json": function(data) {
-    return JSON.stringify(data);
-  }
-};
-Meta.prototype.__defineGetter__('contentType', function() {
-  return this._type;
-});
-Meta.prototype.__defineSetter__('contentType', function(type) {
-  this._type = this.guessType(type || 'json');
-  if (this._type.match(/octet/) || this._type.match(/^image/)) {
-    this.binary = true;
-  } else {
-    this.binary = false;
-  }
-  return this._type;
-});
-module.exports = Meta;
+    }
+  };
+  Meta.prototype.popKey = function(key) {
+    var value;
+    value = this.usermeta[key];
+    delete this.usermeta[key];
+    return value;
+  };
+  Meta.prototype.stringifyQuery = function(query) {
+    var _a, key, value;
+    _a = query;
+    for (key in _a) {
+      if (!__hasProp.call(_a, key)) continue;
+      value = _a[key];
+      if (typeof value === 'boolean') {
+        query[key] = String(value);
+      }
+    }
+    return querystring.stringify(query);
+  };
+  Meta.queryProperties = ['r', 'w', 'dw', 'rw', 'keys', 'props', 'vtag', 'nocache', 'returnbody', 'chunked'];
+  Meta.riakProperties = ['contentType', 'vclock', 'lastMod', 'lastModUsecs', 'charset', 'contentEncoding', 'statusCode', 'links', 'etag', 'raw', 'nocache', 'clientId', 'data', 'host'].concat(Meta.queryProperties);
+  Meta.defaults = {
+    links: [],
+    contentType: 'json',
+    raw: 'riak',
+    clientId: 'riak-js',
+    debug: true,
+    host: 'localhost'
+  };
+  Meta.decoders = {
+    "application/json": function(s) {
+      return JSON.parse(s);
+    }
+  };
+  Meta.encoders = {
+    "application/json": function(data) {
+      return JSON.stringify(data);
+    }
+  };
+  Meta.prototype.__defineGetter__('contentType', function() {
+    return this._type;
+  });
+  Meta.prototype.__defineSetter__('contentType', function(type) {
+    this._type = this.guessType(type || 'json');
+    if (this._type.match(/octet/) || this._type.match(/^image/)) {
+      this.binary = true;
+    } else {
+      this.binary = false;
+    }
+    return this._type;
+  });
+  module.exports = Meta;
+})();

--- a/lib/protobuf.js
+++ b/lib/protobuf.js
@@ -1,225 +1,227 @@
-var Buffer, Connection, Pool, ProtoBuf, events, fs, net, path, sys;
-var __bind = function(func, context) {
+(function() {
+  var Buffer, Connection, Pool, ProtoBuf, events, fs, net, path, sys;
+  var __bind = function(func, context) {
     return function(){ return func.apply(context, arguments); };
   };
-sys = require('sys');
-net = require('net');
-fs = require('fs');
-events = require('events');
-path = require('path');
-Buffer = require('buffer').Buffer;
-Pool = function(options) {
-  this.options = options || {};
-  this.options.port || (this.options.port = 8087);
-  this.options.host || (this.options.host = '127.0.0.1');
-  this.options.max || (this.options.max = 10);
-  this.running = 0;
-  this.pool = [];
-  this.events = new events.EventEmitter();
-  return this;
-};
-Pool.prototype.start = function(callback) {
-  var _ref;
-  if (!(typeof (_ref = this.running) !== "undefined" && _ref !== null)) {
-    return false;
-  }
-  this.next(function(conn) {
-    if (conn.writable) {
-      if (callback) {
-        return callback(conn);
-      }
-    } else {
-      return conn.on('connect', function() {
+  sys = require('sys');
+  net = require('net');
+  fs = require('fs');
+  events = require('events');
+  path = require('path');
+  Buffer = require('buffer').Buffer;
+  Pool = function(options) {
+    this.options = options || {};
+    this.options.port || (this.options.port = 8087);
+    this.options.host || (this.options.host = '127.0.0.1');
+    this.options.max || (this.options.max = 10);
+    this.running = 0;
+    this.pool = [];
+    this.events = new events.EventEmitter();
+    return this;
+  };
+  Pool.prototype.start = function(callback) {
+    var _a;
+    if (!(typeof (_a = this.running) !== "undefined" && _a !== null)) {
+      return false;
+    }
+    this.next(function(conn) {
+      if (conn.writable) {
         if (callback) {
           return callback(conn);
         }
-      });
-    }
-  });
-  return true;
-};
-Pool.prototype.send = function(name, data) {
-  return __bind(function(callback) {
-    return this.start(function(conn) {
-      return conn.send(name, data)(function(resp) {
-        try {
-          return callback(resp);
-        } finally {
-          conn.finish();
-        }
-      });
-    });
-  }, this);
-};
-Pool.prototype.finish = function(conn) {
-  var _ref;
-  if (typeof (_ref = this.running) !== "undefined" && _ref !== null) {
-    this.running -= 1;
-    this.events.emit('finish');
-    if (this.pool.length < this.options.max) {
-      return this.pool.push(conn);
-    }
-  } else {
-    return conn.end();
-  }
-};
-Pool.prototype.end = function() {
-  this.running = null;
-  return this.pool.forEach(function(conn) {
-    return conn.end();
-  });
-};
-Pool.prototype.next = function(callback) {
-  var cb;
-  return this.running >= this.options.max ? this.events.on('finish', cb = __bind(function() {
-    if (this.running < this.options.max) {
-      callback(this.getConnection());
-      return this.events.removeListener('finish', cb);
-    }
-  }, this)) : callback(this.getConnection());
-};
-Pool.prototype.getConnection = function() {
-  this.running += 1;
-  return this.pool.pop() || new Connection(this);
-};
-Connection = function(pool) {
-  this.conn = net.createConnection(pool.options.port, pool.options.host);
-  this.pool = pool;
-  this.conn.on('data', __bind(function(chunk) {
-    return this.receive(chunk);
-  }, this));
-  this.reset();
-  return this;
-};
-Connection.prototype.send = function(name, data) {
-  return __bind(function(callback) {
-    this.callback = callback;
-    return this.conn.write(this.prepare(name, data));
-  }, this);
-};
-Connection.prototype.finish = function() {
-  return this.pool.finish(this);
-};
-Connection.prototype.end = function() {
-  return this.conn.end();
-};
-Connection.prototype.on = function(event, listener) {
-  this.conn.on(event, listener);
-  return this;
-};
-Connection.prototype.prepare = function(name, data) {
-  var buf, len, msg, type;
-  type = ProtoBuf[name];
-  if (data) {
-    buf = type.serialize(data);
-    len = buf.length + 1;
-  } else {
-    len = 1;
-  }
-  msg = new Buffer(len + 4);
-  msg[0] = len >>> 24;
-  msg[1] = len >>> 16;
-  msg[2] = len >>> 8;
-  msg[3] = len & 255;
-  msg[4] = type.riak_code;
-  if (buf) {
-    buf.copy(msg, 5, 0);
-  }
-  return msg;
-};
-Connection.prototype.receive = function(chunk) {
-  var _ref;
-  this.chunk = chunk;
-  return this.attempt_parse() ? ((typeof (_ref = this.pool.running) !== "undefined" && _ref !== null) ? this.reset() : this.end()) : null;
-};
-Connection.prototype.attempt_parse = function() {
-  var _ref, code, data;
-  if (data = this.parse()) {
-    if ((typeof (_ref = data.errmsg) !== "undefined" && _ref !== null) && (typeof (_ref = data.errcode) !== "undefined" && _ref !== null)) {
-      code = data.errcode;
-      data = new Error(data.errmsg);
-      data.errcode = code;
-    }
-    if (this.callback) {
-      this.callback(data);
-    }
-    if (this.chunk_pos < this.chunk.length) {
-      this.resp = null;
-      return this.attempt_parse();
-    } else {
-      return true;
-    }
-  }
-};
-Connection.prototype.parse = function() {
-  var bytes_read, ending;
-  if (this.receiving) {
-    ending = this.resp_len + this.chunk_pos;
-    if (ending > this.chunk.length) {
-      ending = this.chunk.length;
-    }
-    bytes_read = ending - this.chunk_pos;
-    this.chunk.copy(this.resp, this.resp_pos, this.chunk_pos, ending);
-    this.resp_pos += bytes_read;
-    this.chunk_pos += bytes_read;
-    if (this.resp_pos === this.resp_len) {
-      return this.type.parse(this.resp);
-    }
-  } else {
-    this.resp_len = (this.chunk[this.chunk_pos + 0] << 24) + (this.chunk[this.chunk_pos + 1] << 16) + (this.chunk[this.chunk_pos + 2] << 8) + this.chunk[this.chunk_pos + 3] - 1;
-    this.type = ProtoBuf.type(this.chunk[this.chunk_pos + 4]);
-    this.resp = new Buffer(this.resp_len);
-    this.resp_pos = 0;
-    this.chunk_pos += 5;
-    return this.parse();
-  }
-};
-Connection.prototype.reset = function() {
-  this.type = null;
-  this.resp = null;
-  this.chunk = null;
-  this.chunk_pos = 0;
-  this.resp_pos = 0;
-  return (this.resp_len = 0);
-};
-Connection.prototype.__defineGetter__('receiving', function() {
-  return this.resp;
-});
-Connection.prototype.__defineGetter__('writable', function() {
-  return this.conn.writable;
-});
-Pool.Connection = Connection;
-ProtoBuf = {
-  types: ["ErrorResp", "PingReq", "PingResp", "GetClientIdReq", "GetClientIdResp", "SetClientIdReq", "SetClientIdResp", "GetServerInfoReq", "GetServerInfoResp", "GetReq", "GetResp", "PutReq", "PutResp", "DelReq", "DelResp", "ListBucketsReq", "ListBucketsResp", "ListKeysReq", "ListKeysResp", "GetBucketReq", "GetBucketResp", "SetBucketReq", "SetBucketResp", "MapRedReq", "MapRedResp"],
-  type: function(num) {
-    return this[this.types[num]];
-  },
-  schemaFile: path.join(path.dirname(module.filename), 'riak.desc')
-};
-ProtoBuf.__defineGetter__('schema', function() {
-  return this._schema || (this._schema = new (require('protobuf_for_node').Schema)(fs.readFileSync(ProtoBuf.schemaFile)));
-});
-ProtoBuf.types.forEach(function(name) {
-  var cached_name;
-  cached_name = ("_" + (name));
-  return ProtoBuf.__defineGetter__(name, function() {
-    var code, sch;
-    if (this[cached_name]) {
-      return this[cached_name];
-    } else {
-      code = ProtoBuf.types.indexOf(name);
-      if (sch = ProtoBuf.schema[("Rpb" + (name))]) {
-        sch.riak_code = code;
-        return (this[cached_name] = sch);
       } else {
-        return (this[cached_name] = {
-          riak_code: code,
-          parse: function() {
-            return true;
+        return conn.on('connect', function() {
+          if (callback) {
+            return callback(conn);
           }
         });
       }
+    });
+    return true;
+  };
+  Pool.prototype.send = function(name, data) {
+    return __bind(function(callback) {
+      return this.start(function(conn) {
+        return conn.send(name, data)(function(resp) {
+          try {
+            return callback(resp);
+          } finally {
+            conn.finish();
+          }
+        });
+      });
+    }, this);
+  };
+  Pool.prototype.finish = function(conn) {
+    var _a;
+    if (typeof (_a = this.running) !== "undefined" && _a !== null) {
+      this.running -= 1;
+      this.events.emit('finish');
+      if (this.pool.length < this.options.max) {
+        return this.pool.push(conn);
+      }
+    } else {
+      return conn.end();
     }
+  };
+  Pool.prototype.end = function() {
+    this.running = null;
+    return this.pool.forEach(function(conn) {
+      return conn.end();
+    });
+  };
+  Pool.prototype.next = function(callback) {
+    var cb;
+    return this.running >= this.options.max ? this.events.on('finish', cb = __bind(function() {
+      if (this.running < this.options.max) {
+        callback(this.getConnection());
+        return this.events.removeListener('finish', cb);
+      }
+    }, this)) : callback(this.getConnection());
+  };
+  Pool.prototype.getConnection = function() {
+    this.running += 1;
+    return this.pool.pop() || new Connection(this);
+  };
+  Connection = function(pool) {
+    this.conn = net.createConnection(pool.options.port, pool.options.host);
+    this.pool = pool;
+    this.conn.on('data', __bind(function(chunk) {
+      return this.receive(chunk);
+    }, this));
+    this.reset();
+    return this;
+  };
+  Connection.prototype.send = function(name, data) {
+    return __bind(function(callback) {
+      this.callback = callback;
+      return this.conn.write(this.prepare(name, data));
+    }, this);
+  };
+  Connection.prototype.finish = function() {
+    return this.pool.finish(this);
+  };
+  Connection.prototype.end = function() {
+    return this.conn.end();
+  };
+  Connection.prototype.on = function(event, listener) {
+    this.conn.on(event, listener);
+    return this;
+  };
+  Connection.prototype.prepare = function(name, data) {
+    var buf, len, msg, type;
+    type = ProtoBuf[name];
+    if (data) {
+      buf = type.serialize(data);
+      len = buf.length + 1;
+    } else {
+      len = 1;
+    }
+    msg = new Buffer(len + 4);
+    msg[0] = len >>> 24;
+    msg[1] = len >>> 16;
+    msg[2] = len >>> 8;
+    msg[3] = len & 255;
+    msg[4] = type.riak_code;
+    if (buf) {
+      buf.copy(msg, 5, 0);
+    }
+    return msg;
+  };
+  Connection.prototype.receive = function(chunk) {
+    var _a;
+    this.chunk = chunk;
+    return this.attempt_parse() ? ((typeof (_a = this.pool.running) !== "undefined" && _a !== null) ? this.reset() : this.end()) : null;
+  };
+  Connection.prototype.attempt_parse = function() {
+    var _a, _b, code, data;
+    if (data = this.parse()) {
+      if ((typeof (_a = data.errmsg) !== "undefined" && _a !== null) && (typeof (_b = data.errcode) !== "undefined" && _b !== null)) {
+        code = data.errcode;
+        data = new Error(data.errmsg);
+        data.errcode = code;
+      }
+      if (this.callback) {
+        this.callback(data);
+      }
+      if (this.chunk_pos < this.chunk.length) {
+        this.resp = null;
+        return this.attempt_parse();
+      } else {
+        return true;
+      }
+    }
+  };
+  Connection.prototype.parse = function() {
+    var bytes_read, ending;
+    if (this.receiving) {
+      ending = this.resp_len + this.chunk_pos;
+      if (ending > this.chunk.length) {
+        ending = this.chunk.length;
+      }
+      bytes_read = ending - this.chunk_pos;
+      this.chunk.copy(this.resp, this.resp_pos, this.chunk_pos, ending);
+      this.resp_pos += bytes_read;
+      this.chunk_pos += bytes_read;
+      if (this.resp_pos === this.resp_len) {
+        return this.type.parse(this.resp);
+      }
+    } else {
+      this.resp_len = (this.chunk[this.chunk_pos + 0] << 24) + (this.chunk[this.chunk_pos + 1] << 16) + (this.chunk[this.chunk_pos + 2] << 8) + this.chunk[this.chunk_pos + 3] - 1;
+      this.type = ProtoBuf.type(this.chunk[this.chunk_pos + 4]);
+      this.resp = new Buffer(this.resp_len);
+      this.resp_pos = 0;
+      this.chunk_pos += 5;
+      return this.parse();
+    }
+  };
+  Connection.prototype.reset = function() {
+    this.type = null;
+    this.resp = null;
+    this.chunk = null;
+    this.chunk_pos = 0;
+    this.resp_pos = 0;
+    return (this.resp_len = 0);
+  };
+  Connection.prototype.__defineGetter__('receiving', function() {
+    return this.resp;
   });
-});
-module.exports = Pool;
+  Connection.prototype.__defineGetter__('writable', function() {
+    return this.conn.writable;
+  });
+  Pool.Connection = Connection;
+  ProtoBuf = {
+    types: ["ErrorResp", "PingReq", "PingResp", "GetClientIdReq", "GetClientIdResp", "SetClientIdReq", "SetClientIdResp", "GetServerInfoReq", "GetServerInfoResp", "GetReq", "GetResp", "PutReq", "PutResp", "DelReq", "DelResp", "ListBucketsReq", "ListBucketsResp", "ListKeysReq", "ListKeysResp", "GetBucketReq", "GetBucketResp", "SetBucketReq", "SetBucketResp", "MapRedReq", "MapRedResp"],
+    type: function(num) {
+      return this[this.types[num]];
+    },
+    schemaFile: path.join(path.dirname(module.filename), 'riak.desc')
+  };
+  ProtoBuf.__defineGetter__('schema', function() {
+    return this._schema || (this._schema = new (require('protobuf_for_node').Schema)(fs.readFileSync(ProtoBuf.schemaFile)));
+  });
+  ProtoBuf.types.forEach(function(name) {
+    var cached_name;
+    cached_name = ("_" + (name));
+    return ProtoBuf.__defineGetter__(name, function() {
+      var code, sch;
+      if (this[cached_name]) {
+        return this[cached_name];
+      } else {
+        code = ProtoBuf.types.indexOf(name);
+        if (sch = ProtoBuf.schema[("Rpb" + (name))]) {
+          sch.riak_code = code;
+          return (this[cached_name] = sch);
+        } else {
+          return (this[cached_name] = {
+            riak_code: code,
+            parse: function() {
+              return true;
+            }
+          });
+        }
+      }
+    });
+  });
+  module.exports = Pool;
+})();

--- a/lib/protobuf_client.js
+++ b/lib/protobuf_client.js
@@ -1,5 +1,6 @@
-var Client, CoreMeta, Mapper, Meta, Pool, ProtoBufClient, utils;
-var __extends = function(child, parent) {
+(function() {
+  var Client, CoreMeta, Mapper, Meta, Pool, ProtoBufClient, utils;
+  var __extends = function(child, parent) {
     var ctor = function(){};
     ctor.prototype = parent.prototype;
     child.prototype = new ctor();
@@ -9,196 +10,197 @@ var __extends = function(child, parent) {
   }, __slice = Array.prototype.slice, __bind = function(func, context) {
     return function(){ return func.apply(context, arguments); };
   };
-Client = require('./client');
-Pool = require('./protobuf');
-CoreMeta = require('./meta');
-Mapper = require('./mapper');
-utils = require('./utils');
-Meta = function() {
-  return CoreMeta.apply(this, arguments);
-};
-__extends(Meta, CoreMeta);
-Meta.prototype.withContent = function(body) {
-  this.content = {
-    value: this.encode(body),
-    contentType: this.contentType,
-    charset: this.charset,
-    contentEncoding: this.contentEncoding,
-    links: this.encodeLinks(this.links),
-    usermeta: this.encodeUsermeta(this.usermeta)
+  Client = require('./client');
+  Pool = require('./protobuf');
+  CoreMeta = require('./meta');
+  Mapper = require('./mapper');
+  utils = require('./utils');
+  Meta = function() {
+    return CoreMeta.apply(this, arguments);
   };
-  delete this.usermeta;
-  delete this.links;
-  return this;
-};
-Meta.prototype.encodeLinks = function(links) {
-  var parsed;
-  parsed = [];
-  if (links && !utils.isArray(links)) {
-    links = [links];
-  }
-  links.forEach(function(link) {
-    return parsed.push(link);
-  });
-  return parsed;
-};
-Meta.prototype.encodeUsermeta = function(data) {
-  var _ref, key, parsed, value;
-  parsed = [];
-  _ref = data;
-  for (key in _ref) {
-    value = _ref[key];
-    parsed.push({
-      key: key,
-      value: value
-    });
-  }
-  return parsed;
-};
-ProtoBufClient = function() {
-  return Client.apply(this, arguments);
-};
-__extends(ProtoBufClient, Client);
-ProtoBufClient.prototype.get = function(bucket, key) {
-  var _ref, callback, meta, options;
-  options = __slice.call(arguments, 2);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  meta = new Meta(bucket, key, options);
-  return this.send("GetReq", meta)(__bind(function(data) {
-    return this.executeCallback(this.processValueResponse(meta, data), meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.save = function(bucket, key, body) {
-  var _ref, callback, meta, options;
-  options = __slice.call(arguments, 3);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  meta = new Meta(bucket, key, options);
-  return this.send("PutReq", meta.withContent(body))(__bind(function(data) {
-    return this.executeCallback(this.processValueResponse(meta, data), meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.remove = function(bucket, key) {
-  var _ref, callback, meta, options;
-  options = __slice.call(arguments, 2);
-  _ref = this.ensure(options);
-  options = _ref[0];
-  callback = _ref[1];
-  meta = new Meta(bucket, key, options);
-  return this.send("DelReq", meta)(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.add = function(inputs) {
-  return new Mapper(this, inputs);
-};
-ProtoBufClient.prototype.ping = function(callback) {
-  return this.send('PingReq')(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.end = function() {
-  if (this.connection) {
-    return this.connection.end();
-  }
-};
-ProtoBufClient.prototype.buckets = function(callback) {
-  return this.send('ListBucketsReq')(__bind(function(data, meta) {
-    return this.executeCallback(data.buckets, meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.keys = function(bucket, callback) {
-  var keys;
-  keys = [];
-  return this.send('ListKeysReq', {
-    bucket: bucket
-  })(__bind(function(data, meta) {
-    return this.processKeysResponse(data, keys, meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.serverInfo = function(callback) {
-  return this.send('GetServerInfoReq')(__bind(function(data, meta) {
-    return this.executeCallback(data, meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.runJob = function(job, callback) {
-  var body, resp;
-  body = {
-    request: JSON.stringify(job.data),
-    contentType: 'application/json'
+  __extends(Meta, CoreMeta);
+  Meta.prototype.withContent = function(body) {
+    this.content = {
+      value: this.encode(body),
+      contentType: this.contentType,
+      charset: this.charset,
+      contentEncoding: this.contentEncoding,
+      links: this.encodeLinks(this.links),
+      usermeta: this.encodeUsermeta(this.usermeta)
+    };
+    delete this.usermeta;
+    delete this.links;
+    return this;
   };
-  resp = {
-    phases: []
-  };
-  return this.send("MapRedReq", body)(__bind(function(data, meta) {
-    return this.processMapReduceResponse(data, resp, meta, callback);
-  }, this));
-};
-ProtoBufClient.prototype.send = function(name, data) {
-  var _ref;
-  return (typeof (_ref = this.connection) !== "undefined" && _ref !== null) && this.connection.writable ? this.connection.send(name, data) : __bind(function(callback) {
-    return this.pool.start(__bind(function(conn) {
-      this.connection = conn;
-      return this.connection.send(name, data)(callback);
-    }, this));
-  }, this);
-};
-ProtoBufClient.prototype.processKeysResponse = function(data, keys, meta, callback) {
-  if (data.errcode) {
-    this.executeCallback(data, meta, callback);
-  }
-  if (data.keys) {
-    data.keys.forEach(function(key) {
-      return keys.push(key);
-    });
-  }
-  return data.done ? this.executeCallback(keys, meta, callback) : null;
-};
-ProtoBufClient.prototype.processMapReduceResponse = function(data, resp, meta, callback) {
-  var _ref, parsed;
-  if (data.errcode) {
-    this.executeCallback(data, meta, callback);
-  }
-  if (typeof (_ref = data.phase) !== "undefined" && _ref !== null) {
-    if (resp.phases.indexOf(data.phase) === -1) {
-      resp.phases.push(data.phase);
+  Meta.prototype.encodeLinks = function(links) {
+    var parsed;
+    parsed = [];
+    if (links && !utils.isArray(links)) {
+      links = [links];
     }
-    parsed = JSON.parse(data.response);
-    if (typeof (_ref = resp[data.phase]) !== "undefined" && _ref !== null) {
-      parsed.forEach(function(item) {
-        return resp[data.phase].push(item);
+    links.forEach(function(link) {
+      return parsed.push(link);
+    });
+    return parsed;
+  };
+  Meta.prototype.encodeUsermeta = function(data) {
+    var _a, key, parsed, value;
+    parsed = [];
+    _a = data;
+    for (key in _a) {
+      value = _a[key];
+      parsed.push({
+        key: key,
+        value: value
       });
-    } else {
-      resp[data.phase] = parsed;
     }
-  }
-  return data.done ? this.executeCallback(resp, meta, callback) : null;
-};
-ProtoBufClient.prototype.processValueResponse = function(meta, data) {
-  var _ref, content, value;
-  delete meta.content;
-  if ((typeof (_ref = data.content) !== "undefined" && _ref !== null) && (typeof (_ref = data.content[0]) !== "undefined" && _ref !== null) && (typeof (_ref = data.vclock) !== "undefined" && _ref !== null)) {
-    _ref = this.processValue(data.content[0]);
-    content = _ref[0];
-    value = _ref[1];
-    meta.load(content);
-    meta.vclock = data.vclock;
-    return meta.decode(value);
-  }
-};
-ProtoBufClient.prototype.processValue = function(content) {
-  var _ref, value;
-  value = content.value;
-  if (typeof (_ref = content.usermeta == null ? undefined : content.usermeta.forEach) !== "undefined" && _ref !== null) {
-    content.usermeta.forEach(function(pair) {
-      return (content[pair.key] = pair.value);
-    });
-  }
-  delete content.value;
-  delete content.usermeta;
-  return [content, value];
-};
-module.exports = ProtoBufClient;
+    return parsed;
+  };
+  ProtoBufClient = function() {
+    return Client.apply(this, arguments);
+  };
+  __extends(ProtoBufClient, Client);
+  ProtoBufClient.prototype.get = function(bucket, key) {
+    var _a, callback, meta, options;
+    options = __slice.call(arguments, 2);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    meta = new Meta(bucket, key, options);
+    return this.send("GetReq", meta)(__bind(function(data) {
+      return this.executeCallback(this.processValueResponse(meta, data), meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.save = function(bucket, key, body) {
+    var _a, callback, meta, options;
+    options = __slice.call(arguments, 3);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    meta = new Meta(bucket, key, options);
+    return this.send("PutReq", meta.withContent(body))(__bind(function(data) {
+      return this.executeCallback(this.processValueResponse(meta, data), meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.remove = function(bucket, key) {
+    var _a, callback, meta, options;
+    options = __slice.call(arguments, 2);
+    _a = this.ensure(options);
+    options = _a[0];
+    callback = _a[1];
+    meta = new Meta(bucket, key, options);
+    return this.send("DelReq", meta)(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.add = function(inputs) {
+    return new Mapper(this, inputs);
+  };
+  ProtoBufClient.prototype.ping = function(callback) {
+    return this.send('PingReq')(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.end = function() {
+    if (this.connection) {
+      return this.connection.end();
+    }
+  };
+  ProtoBufClient.prototype.buckets = function(callback) {
+    return this.send('ListBucketsReq')(__bind(function(data, meta) {
+      return this.executeCallback(data.buckets, meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.keys = function(bucket, callback) {
+    var keys;
+    keys = [];
+    return this.send('ListKeysReq', {
+      bucket: bucket
+    })(__bind(function(data, meta) {
+      return this.processKeysResponse(data, keys, meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.serverInfo = function(callback) {
+    return this.send('GetServerInfoReq')(__bind(function(data, meta) {
+      return this.executeCallback(data, meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.runJob = function(job, callback) {
+    var body, resp;
+    body = {
+      request: JSON.stringify(job.data),
+      contentType: 'application/json'
+    };
+    resp = {
+      phases: []
+    };
+    return this.send("MapRedReq", body)(__bind(function(data, meta) {
+      return this.processMapReduceResponse(data, resp, meta, callback);
+    }, this));
+  };
+  ProtoBufClient.prototype.send = function(name, data) {
+    var _a;
+    return (typeof (_a = this.connection) !== "undefined" && _a !== null) && this.connection.writable ? this.connection.send(name, data) : __bind(function(callback) {
+      return this.pool.start(__bind(function(conn) {
+        this.connection = conn;
+        return this.connection.send(name, data)(callback);
+      }, this));
+    }, this);
+  };
+  ProtoBufClient.prototype.processKeysResponse = function(data, keys, meta, callback) {
+    if (data.errcode) {
+      this.executeCallback(data, meta, callback);
+    }
+    if (data.keys) {
+      data.keys.forEach(function(key) {
+        return keys.push(key);
+      });
+    }
+    return data.done ? this.executeCallback(keys, meta, callback) : null;
+  };
+  ProtoBufClient.prototype.processMapReduceResponse = function(data, resp, meta, callback) {
+    var _a, _b, parsed;
+    if (data.errcode) {
+      this.executeCallback(data, meta, callback);
+    }
+    if (typeof (_b = data.phase) !== "undefined" && _b !== null) {
+      if (resp.phases.indexOf(data.phase) === -1) {
+        resp.phases.push(data.phase);
+      }
+      parsed = JSON.parse(data.response);
+      if (typeof (_a = resp[data.phase]) !== "undefined" && _a !== null) {
+        parsed.forEach(function(item) {
+          return resp[data.phase].push(item);
+        });
+      } else {
+        resp[data.phase] = parsed;
+      }
+    }
+    return data.done ? this.executeCallback(resp, meta, callback) : null;
+  };
+  ProtoBufClient.prototype.processValueResponse = function(meta, data) {
+    var _a, _b, _c, _d, content, value;
+    delete meta.content;
+    if ((typeof (_b = data.content) !== "undefined" && _b !== null) && (typeof (_c = data.content[0]) !== "undefined" && _c !== null) && (typeof (_d = data.vclock) !== "undefined" && _d !== null)) {
+      _a = this.processValue(data.content[0]);
+      content = _a[0];
+      value = _a[1];
+      meta.load(content);
+      meta.vclock = data.vclock;
+      return meta.decode(value);
+    }
+  };
+  ProtoBufClient.prototype.processValue = function(content) {
+    var _a, value;
+    value = content.value;
+    if (typeof (_a = content.usermeta == null ? undefined : content.usermeta.forEach) !== "undefined" && _a !== null) {
+      content.usermeta.forEach(function(pair) {
+        return (content[pair.key] = pair.value);
+      });
+    }
+    delete content.value;
+    delete content.usermeta;
+    return [content, value];
+  };
+  module.exports = ProtoBufClient;
+})();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,48 +1,49 @@
-module.exports = {
-  isArray: function(obj) {
-    return !!(obj && obj.concat && obj.unshift && !obj.callee);
-  },
-  toJSON: function(data) {
-    return JSON.stringify(data, function(key, val) {
-      return typeof val === 'function' ? val.toString() : val;
-    });
-  },
-  parseMultipart: function(data, boundary) {
-    var _ref, _ref2, escape;
-    escape = function(text) {
-      return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
-    };
-    data = ((typeof (_ref2 = ((_ref = data.split(new RegExp("\r?\n--" + (escape(boundary)) + "--\r?\n"))))) === "undefined" || _ref2 === null) ? undefined : _ref2[0]) || "";
-    return data.split(new RegExp("\r?\n--" + (escape(boundary)) + "\r?\n")).filter(function(e) {
-      return !!e;
-    }).map(function(part) {
-      var _ref3, body, headers, hs, md;
-      if (md = part.split(/\r?\n\r?\n/)) {
-        _ref3 = md;
-        headers = _ref3[0];
-        body = _ref3[1];
-        hs = {};
-        headers.split(/\r?\n/).forEach(function(header) {
-          var _ref4, k, v;
-          _ref4 = header.split(': ');
-          k = _ref4[0];
-          v = _ref4[1];
-          return (hs[k.toLowerCase()] = v);
-        });
-        return {
-          headers: hs,
-          body: body
-        };
-      }
-    }).filter(function(e) {
-      return !!e;
-    });
-  },
-  extractBoundary: function(header_string) {
-    var c;
-    return (c = header_string.match(/boundary=([A-Za-z0-9\'()+_,-.\/:=?]+)/)) ? c[1] : null;
-  },
-  mixin: function() {
+(function() {
+  module.exports = {
+    isArray: function(obj) {
+      return !!(obj && obj.concat && obj.unshift && !obj.callee);
+    },
+    toJSON: function(data) {
+      return JSON.stringify(data, function(key, val) {
+        return typeof val === 'function' ? val.toString() : val;
+      });
+    },
+    parseMultipart: function(data, boundary) {
+      var _a, _b, escape;
+      escape = function(text) {
+        return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+      };
+      data = ((typeof (_b = ((_a = data.split(new RegExp("\r?\n--" + (escape(boundary)) + "--\r?\n"))))) === "undefined" || _b === null) ? undefined : _b[0]) || "";
+      return data.split(new RegExp("\r?\n--" + (escape(boundary)) + "\r?\n")).filter(function(e) {
+        return !!e;
+      }).map(function(part) {
+        var _c, body, headers, hs, md;
+        if (md = part.split(/\r?\n\r?\n/)) {
+          _c = md;
+          headers = _c[0];
+          body = _c[1];
+          hs = {};
+          headers.split(/\r?\n/).forEach(function(header) {
+            var _d, k, v;
+            _d = header.split(': ');
+            k = _d[0];
+            v = _d[1];
+            return (hs[k.toLowerCase()] = v);
+          });
+          return {
+            headers: hs,
+            body: body
+          };
+        }
+      }).filter(function(e) {
+        return !!e;
+      });
+    },
+    extractBoundary: function(header_string) {
+      var c;
+      return (c = header_string.match(/boundary=([A-Za-z0-9\'()+_,-.\/:=?]+)/)) ? c[1] : null;
+    },
+    mixin: function() {
       // copy reference to target object
       var target = arguments[0] || {}, i = 1, length = arguments.length, deep = false, source;
 
@@ -91,4 +92,5 @@ module.exports = {
       // Return the modified object
       return target;
     }
-};
+  };
+})();

--- a/test/meta_test.coffee
+++ b/test/meta_test.coffee
@@ -23,3 +23,47 @@ assert.equal true,        full.binary
 full.contentType = 'xml'
 assert.equal 'text/xml', full.contentType
 assert.equal false,      full.binary
+
+keyless = new Meta 'bucket'
+assert.equal '/riak/bucket/', keyless.url
+
+keyed = new Meta 'bucket', 'key'
+assert.equal '/riak/bucket/key', keyed.url
+assert.deepEqual {}, keyed.queryProps
+assert.equal "", keyed.queryString
+assert.equal "/riak/bucket/key", keyed.path
+
+assert.deepEqual ['r', 'w', 'dw', 'rw', 'keys', 'props',
+'vtag', 'nocache', 'returnbody', 'chunked'], Meta.queryProperties
+
+assert.deepEqual ['contentType', 'vclock', 'lastMod', 'lastModUsecs',
+  'charset', 'contentEncoding', 'statusCode', 'links', 'etag',
+  'raw', 'nocache', 'clientId', 'data', 'host', 'r', 'w',
+  'dw', 'rw', 'keys', 'props', 'vtag', 'nocache', 'returnbody', 'chunked'], Meta.riakProperties
+
+queryProps =
+  r: 1
+  w: 2
+  dw: 2
+  rw: 2
+  keys: true
+  props: false
+  vtag: 'asweetvtag'
+  returnbody: true
+  chunked: true
+
+stringifiedQueryProps =
+  r: '1'
+  w: '2'
+  dw: '2'
+  rw: '2'
+  keys: 'true'
+  props: 'false'
+  vtag: 'asweetvtag'
+  returnbody: 'true'
+  chunked: 'true'
+
+withQueryProps = new Meta 'bucket', 'key', queryProps
+assert.deepEqual stringifiedQueryProps, withQueryProps.queryProps
+assert.equal "r=1&w=2&dw=2&rw=2&keys=true&props=false&vtag=asweetvtag&returnbody=true&chunked=true", withQueryProps.queryString
+assert.equal "/riak/bucket/key?r=1&w=2&dw=2&rw=2&keys=true&props=false&vtag=asweetvtag&returnbody=true&chunked=true", withQueryProps.path


### PR DESCRIPTION
Hey Frank,

This branch moves some of the query string generation out of the execute method on http_client and into meta. I was having trouble using the returnBody parameter because the set of riak properties that are considered querystring properties is defined twice: once in Meta.riakProperties and once in the http_client.execute. The returnBody parameter is spelled differently and subsequently is it getting put into  usermeta instead of being sent along as a querystring parameter. Instead of fixing the spelling error I decided to take a crack at removing the duplication instead. In test--driving this I also stumbled across another bug where passing a value of false for a querystring parameter such as props resulted in that parameter being removed entirely, instead of being added to the querystring with a value of 'false'. This branch fixes both of those issues. All the tests still pass and I added some additional tests to meta_test to cover the refactoring I did. I tried to keep my overall changes to a minimum, the real goal being to fix the returnBody/false value issues. The branch has a bunch of changes to the .js files but the only .coffee code I changed is in meta, http_client, and meta_test. I think the .js changes are artifacts from compiling. Let me know if this is acceptable or if it needs any tweaks. Thanks!

Justin Marney
