### PR TITLE
fix getClient

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -18,7 +18,7 @@ module.exports =
   getClient: (options) ->
     options or= {}
     options.api or= module.exports.defaults.api
-    @[options.api] options
+    module.exports[options.api] options
 
 module.exports.__defineGetter__ 'ProtoBufClient', ->
   @_pbcClient ||= require './protobuf_client'


### PR DESCRIPTION
getClient uses @ (this) to get the desired API, but that doesn't work for me. I have to name module.exports explicitly.
