### PR TITLE
URL encode bucket and key when building paths

### DIFF
--- a/src/http_meta.coffee
+++ b/src/http_meta.coffee
@@ -83,8 +83,8 @@ class Meta extends CoreMeta
 
 Meta::__defineGetter__ 'path', ->
   queryString = @stringifyQuery @queryProps
-  bq = if @bucket then "/#{@bucket}" else ''
-  kq = if @key then "/#{@key}" else ''
+  bq = if @bucket then "/#{encodeURIComponent(@bucket)}" else ''
+  kq = if @key then "/#{encodeURIComponent(@key)}" else ''
   qs = if queryString then "?#{queryString}" else ''
   "/" + @raw + bq + kq + qs
 


### PR DESCRIPTION
The bucket and key should be escaped when building paths for Riak's HTTP client.

(Sorry for the 2nd pull request, probably could have rolled them both into one)
