### PR TITLE
Fix compatibility with npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/index");

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
            "url": "git://github.com/frank06/riak-js.git" 
        } 
    ],
+   "main": "index",
    "directories": {
        "lib": "./lib"
    },


### PR DESCRIPTION
Hi Frank,

It looks like your latest beta somehow broke compatibility with npm -- `require("riak-js")` was no longer working for me.

These changes add some more specificity to the package for how it should be loaded up, and makes npm happy on my end.

I'm using node 0.2.5 with npm 0.2.16.

Thanks again for the awesome module!
