### PR TITLE
Luwak locations won't parse

### DIFF
--- a/src/http_meta.coffee
+++ b/src/http_meta.coffee
@@ -41,7 +41,7 @@ class Meta extends CoreMeta
     
     # location
     if headers.location
-      [$0, @raw, @bucket, @key] = headers.location.match /\/([^\/]+)\/([^\/]+)\/([^\/]+)/
+      [$0, @raw, @bucket, @key] = headers.location.match /^\/([^\/]+)(?:\/([^\/]+))?\/([^\/]+)$/
     
     return this
 


### PR DESCRIPTION
Luwak locations have no bucket and are of the form:

/luwak/key

The location regex in http_meta.coffee will die when trying to parse them. I would write a test case for this, but I can't get the test suite to run on my machine.
