### PR TITLE
npm 1.0 compatibility changes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# npm 1.0 and 0.3 compatible build script 
+GLOBAL_CAKE=`which cake`
+LOCAL_CAKE="./node_modules/coffee-script/bin/cake"
+
+if [ -n $GLOBAL_CAKE ]; then
+    $GLOBAL_CAKE build
+elif [ -f $LOCAL_CAKE ]; then
+    $LOCAL_CAKE build
+else 
+    echo "No cake executable found, cannot compile. :-("
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
    },
    "os": [ "linux", "darwin" ],
    "dependencies": {"coffee-script": ">=1.0.1"},
-   "scripts": {"install": "./node_modules/coffee-script/bin/cake build"},
+   "scripts": {"install": "./build.sh"},
    "engines": { "node": ">=0.1.97" }
 }


### PR DESCRIPTION
I've added coffee-script as a dependency and added a script that will run 'cake build' post-install in order to get riak-js working with npm 1.0 and node 0.4.x.  The script looks for a globally installed 'cake' first, so works with older versions of npm.  
