### PR TITLE
Allow slashes, spaces and other URI entities in session id.

### DIFF
--- a/src/session_store.coffee
+++ b/src/session_store.coffee
@@ -2,6 +2,10 @@
 
 Store.prototype.constructor = Store
 
+uriSafe = (key="") ->
+  encodeURIComponent(key.replace(/\+/g, "%20"));
+  
+
 class SessionStore extends Store
   constructor: (options) ->
     super options
@@ -9,10 +13,10 @@ class SessionStore extends Store
     @bucket = options.bucket || '_sessions'
 
   set: (sid, sess, cb) ->
-    @client.save @bucket, sid, sess, cb
+    @client.save @bucket, uriSafe(sid), sess, cb
 
   get: (sid, cb) ->
-    @client.get @bucket, sid, (err, data, meta) ->
+    @client.get @bucket, uriSafe(sid), (err, data, meta) ->
       if err?
         
         if meta.statusCode >= 400 && meta.statusCode < 500
@@ -23,7 +27,7 @@ class SessionStore extends Store
         cb(null, data) if cb
 
   destroy: (sid, cb) ->
-    @client.remove @bucket, sid, cb
+    @client.remove @bucket, uriSafe(sid), cb
 
   all: (cb) ->
     @client.getAll @bucket, (err, sessions) ->


### PR DESCRIPTION
Hi Frank,

The current release candidate's Session module intermittently breaks. This is due to URI entities finding their way into the randomly generated session id. The fix is to simply URI encode the session id before passing from the session middleware over to the rest of riak-js.
