### PR TITLE
URI encode the bucket name and document name when constructing the HTTP path

### DIFF
--- a/src/http_meta.coffee
+++ b/src/http_meta.coffee
@@ -1,6 +1,9 @@
 CoreMeta = require './meta'
 Utils = require './utils'
 
+uriSafe = (key="") ->
+  encodeURIComponent key.replace /\+/g, "%20"
+
 class Meta extends CoreMeta
 
   load: (options) ->
@@ -94,8 +97,8 @@ class Meta extends CoreMeta
 
 Meta::__defineGetter__ 'path', ->
   queryString = @stringifyQuery @queryProps
-  bq = if @bucket then "/#{@bucket}" else ''
-  kq = if @key then "/#{@key}" else ''
+  bq = if @bucket then "/#{uriSafe @bucket}" else ''
+  kq = if @key then "/#{uriSafe @key}" else ''
   qs = if queryString then "?#{queryString}" else ''
   "/" + @raw + bq + kq + qs
 


### PR DESCRIPTION
Hello again,

Correct me if I'm wrong, but it seems we can fix the URI encoding issue by simply encoding the bucket name and the document key within the HTTP Meta path getter. This seems to take care of the session-ware issue, at least.

Is there anywhere else that this fix would need to be applied? Will this negatively affect anything that I'm missing?

Dan
