### PR TITLE
Fixed SessionStore bug (discussed in IRC with seancribbs)

### DIFF
--- a/spec/test_session_store.coffee
+++ b/spec/test_session_store.coffee
@@ -43,8 +43,7 @@ suite.addBatch
           store.get 'frank', @callback
           undefined
         'successfully': (err, data) ->
-          assert.isNotNull err
-          assert.equal err.errno, process.ENOENT
+          assert.isUndefined err
           assert.isUndefined data
 
 suite.addBatch

--- a/src/session_store.coffee
+++ b/src/session_store.coffee
@@ -18,7 +18,7 @@ class SessionStore extends Store
         if meta.statusCode >= 400 && meta.statusCode < 500
           err.errno = process.ENOENT
         
-        cb(err, null) if cb
+        cb() if cb
       else
         cb(null, data) if cb
 


### PR DESCRIPTION
Fixed SessionStore bug: store.get was calling callback with (err,null) when it should call it with no parameters (err being undefined) when it doesn't find the session in riak. See connect's MemoryStore implementation for reference: https://github.com/senchalabs/connect/blob/master/lib/middleware/session/memory.js
