### PR TITLE
Setting host/port in getClient (website docs)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -103,7 +103,10 @@ db.getAll('flights', { where: { ready: true }})
 var db = require('riak-js').getClient()
 
 // git clone git://github.com/frank06/riak-js.git  # or cloning the repo
-var db = require('/path/to/riak-js/lib').getClient()</code></pre>
+var db = require('/path/to/riak-js/lib').getClient()
+
+// configure the host and port
+var db = require('riak-js').getClient({host: "riak.myhost", port: "8098" });</code></pre>
 
         <p>Or specify the API: <code>getClient({api: 'protobuf'})</code>.</p>
         


### PR DESCRIPTION
I've added a third sample to the setup section for explicitly setting your host & port, which my project requires for production as riak is not on the same machine. I felt it was worth being explicit in the sample docs for how you do this as anyone doing the same in production would need this.
