### PR TITLE
Support new "presort" SOLR parameter

### DIFF
--- a/src/http_meta.coffee
+++ b/src/http_meta.coffee
@@ -127,6 +127,7 @@ Meta.queryProperties = [
   'rows' # search
   'wt' # search
   'sort' # search
+  'presort' # search
 ]
 
 Meta.riakProperties = ['statusCode', 'host', 'responseEncoding']


### PR DESCRIPTION
I recently had a patch accepted to riaksearch which adds a new SOLR parameter, "presort". (https://github.com/basho/riak_search/commit/92b9dc9051ec545bf6246dc6dc897b67ff00625f) This change simply updates riak-js to be aware of that parameter.

I'm not sure exactly when my riaksearch patch will make it into a release, but this change to riak-js should be backwards compatible.

-Greg
