### PR TITLE
Fixing link to Riak wiki

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
       
       <h1>riak-js</h1>
       <div>
-        <h4><a href="http://nodejs.org">Node.js</a> <a href="http://riak.basho.com">Riak</a> client with support for HTTP and Protocol Buffers.</h4>
+        <h4><a href="http://nodejs.org">Node.js</a> <a href="http://wiki.basho.com">Riak</a> client with support for HTTP and Protocol Buffers.</h4>
         
                 <pre>
 <code>db.save('airlines', 'KLM', {fleet: 111, country: 'NL'}, { links:


### PR DESCRIPTION
Changed Riak link to correct address of 'wiki.basho.com' from 'riak.basho.com' (I know if currently redirects correctly to the wiki, but I figured it couldn't hurt to rectify it.) 
