### PR TITLE
Add https client

### DIFF
--- a/src/http_client.coffee
+++ b/src/http_client.coffee
@@ -7,7 +7,9 @@ http = require 'http'
 
 class HttpClient extends Client
   constructor: (options) ->
+    options = options || {}
     options = Utils.mixin true, {}, Meta.defaults, options
+    @_http = options.http || http
     super options
 
   get: (bucket, key, options...) ->
@@ -212,7 +214,7 @@ class HttpClient extends Client
     meta.headers = meta.toHeaders()    
     Client.debug "#{meta.method} #{meta.path}", meta
 
-    request = http.request meta, (response) =>
+    request = @_http.request meta, (response) =>
       
       # using meta as options, to which the HTTP Agent is attached
       # we don't want to carry this around in a Meta

--- a/src/https_client.coffee
+++ b/src/https_client.coffee
@@ -1,0 +1,11 @@
+https = require 'https'
+HttpClient = require './http_client'
+
+{ EventEmitter } = require 'events'
+
+class HttpsClient extends HttpClient
+  constructor: (options) ->
+    options.http = options.http || https
+    super options
+
+module.exports = HttpsClient

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,6 +3,9 @@ module.exports =
   # Gets a new client instance using the HTTP REST api.
   http: (options) -> new @HttpClient options
 
+  # Gets a new client instance using the HTTP REST api over SSL.
+  https: (options) -> new @HttpsClient options
+
   # Gets a new client instance using the protocol buffer api.
   protobuf: (options) ->
     options ||= {}
@@ -28,6 +31,9 @@ module.exports =
 
 module.exports.__defineGetter__ 'HttpClient', ->
   @_httpClient ||= require './http_client'
+
+module.exports.__defineGetter__ 'HttpsClient', ->
+  @_httpsClient ||= require './https_client'
 
 module.exports.__defineGetter__ 'ProtobufClient', ->
   @_pbcClient ||= require './protobuf_client'


### PR DESCRIPTION
I need to talk to a Riak cluster that's using SSL.

Added an "HttpsClient" which inherits from the "HttpClient", and made the specific "http" implementation swappable so that it can put `require("https")` in there instead.
