### PR TITLE
date should be forwarded into meta because last-modified is not present i

### DIFF
--- a/src/http_meta.coffee
+++ b/src/http_meta.coffee
@@ -14,10 +14,11 @@ class Meta extends CoreMeta
     'last-modified': 'lastMod'
     'content-range': 'contentRange'
     'accept-ranges': 'acceptRanges'
+    'date': 'date'
 
     # other response info:
     # statusCode, X-Riak-Meta-* (=> usermeta), link (=> links) Location (=> key)
-    # ignored headers: Vary, Server, Date, Content-Length, Transfer-Encoding
+    # ignored headers: Vary, Server, Content-Length, Transfer-Encoding
 
   loadResponse: (response) ->
     headers = response.headers


### PR DESCRIPTION
date should be forwarded into meta because last-modified is not present in a put/post reply.

macpro1:riak-js siculars$ curl http://127.0.0.1:8098/riak/test -X POST -d"test" -i
HTTP/1.1 201 Created
Vary: Accept-Encoding
Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
Location: /riak/test/VRPdMYaOf9Df8mfu7jiWoFy186f
Date: Thu, 15 Sep 2011 07:43:34 GMT
Content-Type: application/x-www-form-urlencoded
Content-Length: 0

macpro1:riak-js siculars$ curl http://127.0.0.1:8098/riak/test/test1 -X PUT -d"test" -i
HTTP/1.1 204 No Content
Vary: Accept-Encoding
Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
Date: Thu, 15 Sep 2011 07:43:55 GMT
Content-Type: application/x-www-form-urlencoded
Content-Length: 0

macpro1:riak-js siculars$ curl http://127.0.0.1:8098/riak/test/test1 -i
HTTP/1.1 200 OK
X-Riak-Vclock: a85hYGBgzGDKBVIcypz/fvoVqhZkMCUy5rEy7NZ4dpwvCwA=
Vary: Accept-Encoding
Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
Link: </riak/test>; rel="up"
Last-Modified: Thu, 15 Sep 2011 07:43:55 GMT
ETag: "51h3q7RjTNaHWYpO4P0MJj"
Date: Thu, 15 Sep 2011 07:44:05 GMT
Content-Type: application/x-www-form-urlencoded
Content-Length: 4

testmacpro1:riak-js siculars$ 
