### PR TITLE
Convert multipart buffer to string before regex'ing it

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -6,7 +6,7 @@ module.exports =
     
     escape = (text) -> text.replace /[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"
     
-    data = data.split(new RegExp("\r?\n--#{escape boundary}--\r?\n"))?[0] or ""
+    data = data.toString().split(new RegExp("\r?\n--#{escape boundary}--\r?\n"))?[0] or ""
     
     data.split(new RegExp("\r?\n--#{escape boundary}\r?\n")).filter((e) -> !!e).map (part) ->
 


### PR DESCRIPTION
Ran across this while trying out some sibling stuff. I can't say for sure if it happened before I upgraded my local Node to 0.6.1, but this fixes the issue in the simplest way I could think of. If there's a better way, hit me!
