### PR TITLE
Wrap data in Buffer before sending it.

### DIFF
--- a/src/meta.coffee
+++ b/src/meta.coffee
@@ -69,7 +69,7 @@ class Meta
 
   # calls encode on data
   encodeData: () ->
-    @data = @encode(@data) if @data?
+    @data = new Buffer @encode(@data) if @data?
 
   # Fills in a full content type based on a few defaults
   resolveType: (type) ->


### PR DESCRIPTION
Fixes problems with strings containing Unicode characters, leading
to false content length values. I can't remember this having come up in earlier versions of node, but it certainly bit me with 0.6, leading to some weird errors in the Riak Search commit hook.
