### PR TITLE
getProps() throws a TypeError if get() failed

### DIFF
--- a/src/http_client.coffee
+++ b/src/http_client.coffee
@@ -124,7 +124,7 @@ class HttpClient extends Client
   getProps: (bucket, options...) ->
     [options, callback] = @ensure options
     @get bucket, undefined, options, (err, obj) ->
-      callback(err, obj.props)
+      callback(err, obj?.props)
 
   updateProps: (bucket, props, options...) ->
     [options, callback] = @ensure options


### PR DESCRIPTION
If should only return obj.props if obj is valid.
