### PR TITLE
ANNOYING RED SPOT ON MY NPM INSTALLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
        }   
    ],
    "bugs": {
-       "web": "http://github.com/frank06/riak-js/issues" 
+       "url": "http://github.com/frank06/riak-js/issues" 
    },
    "licenses": [
        {


### PR DESCRIPTION
Just because I'm tired of seeing "npm WARN riak-js@0.4.1 package.json: bugs['web'] should probably be bugs['url']" when I `npm install` :)
