### PR TITLE
Allow installation on Solaris family

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
    "directories": {
        "lib": "./lib"
    },
-   "os": [ "linux", "darwin" ],
+   "os": [ "linux", "darwin", "sunos" ],
    "dependencies": {},
    "devDependencies": {
      "vows": "*",


### PR DESCRIPTION
The packages.json file contains OS dependencies that needlessly excludes Solaris/OpenIndiana/SmartOS. I've added the required word to packages.json to allow installation on these systems.
