### PR TITLE
Permit Search to use host other than Localhost

### DIFF
--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -27,7 +27,7 @@ var HttpClient = function HttpClient(options) {
   var execute = function(meta) {
     this._execute(meta)
   }.bind(this);
-  this.search = new HttpSearchClient(execute);
+  this.search = new HttpSearchClient(this._defaults, execute);
   this.mapreduce = new HttpMapReduceClient(this._defaults, execute);
 }
 

--- a/lib/http-search-client.js
+++ b/lib/http-search-client.js
@@ -7,11 +7,27 @@ var XML = require('xml'),
  * in the HttpClient, therefore doesn't have any coupling to the
  * underlying transport.
  *
+ * @param {Object} options
  * @param {Function} callback(meta)
  */
-var HttpSearchClient = function HttpSearchClient(callback) {
+var HttpSearchClient = function HttpSearchClient(options, callback) {
   this._execute = callback;
   this._defaults = {resource: 'solr', method: 'get'};
+
+  // need to add the options to the defaults object so as to not overwrite them
+  // for the calling http-client
+
+  if (options.host) {
+    this._defaults.host = options.host;
+  }
+
+  if (options.port) {
+    this._defaults.port = options.port;
+  }
+
+  if (options.client) {
+    this._defaults.client = options.client;
+  }
 }
 
 /**


### PR DESCRIPTION
Currently, there are no options permitted for HttpSearchClient. As a result of this, you can't specify a non-default host (i.e. my.riak.host.whatever.com) for search calls, resulting in node.js connection refused errors.

The connection refused errors should probably be caught and returned back to the caller, but this proposal allows passing the options passed to getClient() down to the search layer.

I'm not familiar with your style so please propose suggestions.
