### PR TITLE
Unit Test for connection refused 

### DIFF
--- a/test/http-client-test.js
+++ b/test/http-client-test.js
@@ -167,6 +167,13 @@ seq()
     
     db2.get('users', 'test@gmail.com');
   })
+
+  .seq(function() {
+    test('Ensure riak-js gracefully handles a down riak connection');
+    db2.get('users', 'test@gmail.com', function(err, user, meta) {
+      assert.ok(err);
+    });
+  })
   
   .seq(function() {
     test('Save with returnbody=true actually returns the body');


### PR DESCRIPTION
I've added a unit test (that presently fails) to make sure riak-js correctly handles a connection refused error.

The following code works as expected on riak-js 0.4.x, whereas on riak-js 0.9.x it crashes before 'here.' I would have preferred to offer the built in connection failure handling into riak-js proper, but I'm not yet familiar enough with the code to make that change. I thought this was a good starting point.

``` javascript
var riak = require('riak-js');

// This is a non-existant server
var db = riak.getClient({ port: 3456 });

db.get('cars', 'ferrari', function(err, car, meta) {
    console.log('here');
    console.dir(err);
});
```
