### PR TITLE
remove os field

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "directories": {
     "lib": "./lib"
   },
- "dependencies": {
+  "dependencies": {
     "xml": "0.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
since it's a library written in pure js i don't see the point in keeping the `os` field (which makes the installation fail on windows and solaris).

let me know if i missed something,

cheers,

// yawnt
