### PR TITLE
Removed unwanted error in `ping` and `save` operation callbacks

### DIFF
--- a/lib/protocol-buffers-client.js
+++ b/lib/protocol-buffers-client.js
@@ -91,7 +91,7 @@ ProtocolBuffersClient.prototype._execute = function(operation, meta, includePara
       data = meta.parse(response.content[0].value);
     }
 
-    if (expectedResponseOperations.indexOf(operation) > -1 && Object.keys(response).length == 0) {
+    if (Object.keys(response).length == 0 && expectedResponseOperations.indexOf(operation) > -1) {
       error = {notFound: true};
     }
 


### PR DESCRIPTION
This is in response to a bug that appeared when I switch my application to the protobuf API. Sending ping and save commands threw errors like `{notFound: true}` which I found to be unwanted in the case of operations that do not return any data.

This very simple fix only checks to see if the operation requires a response body before making the said error and passing it to the callback.
