### PR TITLE
Fix to allow key retrieval when using protocol buffers

### DIFF
--- a/lib/protocol-buffers-meta.js
+++ b/lib/protocol-buffers-meta.js
@@ -9,6 +9,9 @@ var ProtocolBuffersMeta = function ProtocolBuffersMeta(options) {
 util.inherits(ProtocolBuffersMeta, Meta);
 
 ProtocolBuffersMeta.prototype.loadResponse = function(response) {
+
+  if(response.key !== undefined) this.key = response.key;
+
   if (response.content !== undefined) {
     var content = response.content[0];
     this.contentType = content.content_type;


### PR DESCRIPTION
If you let Riak create the key by passing undefined to the save method, it will not get the key value (as it only uses the meta data passed into it). This patch checks for a key value in the response and sets it accordingly.
