### PR TITLE
201 is a normal status code

### DIFF
--- a/lib/http-request.js
+++ b/lib/http-request.js
@@ -61,7 +61,7 @@ HttpRequest.prototype.execute = function() {
   this.client.emit('riak.request.start', this.event)
 
   var request = httpClient.request(meta, function(err, response) {
-    var normalstatus = [200,204,300,304];
+    var normalstatus = [200,201,204,300,304];
     if(self.event.method == 'delete') normalstatus.push(404);
     // Are we using a connection pool and do we have any errors ?
     if (meta._pool && err) return callback(err);


### PR DESCRIPTION
201 is returned by riak when saving data without specifying a key. Riak will then generate a key by itself and return 201 'CREATED', which was being treated as an error.

http://docs.basho.com/riak/1.2.0/tutorials/fast-track/Basic-Riak-API-Operations/
