### PR TITLE
Improve 404 handling

### DIFF
--- a/lib/http-request.js
+++ b/lib/http-request.js
@@ -66,7 +66,7 @@ HttpRequest.prototype.execute = function() {
     // Are we using a connection pool and do we have any errors ?
     if (meta._pool && err) return callback(err);
     if (meta._pool && normalstatus.indexOf(response.statusCode) == -1) {
-      if (response.statusCode == 404 && !meta.noError404) {
+      if (response.statusCode != 404 || !meta.noError404) {
         var e = new Error();
         e.message = 'Invalid StatusCode: '+ response;
         e.statusCode = response.statusCode;

--- a/lib/http-request.js
+++ b/lib/http-request.js
@@ -66,10 +66,12 @@ HttpRequest.prototype.execute = function() {
     // Are we using a connection pool and do we have any errors ?
     if (meta._pool && err) return callback(err);
     if (meta._pool && normalstatus.indexOf(response.statusCode) == -1) {
-      var e = new Error();
-      e.message = 'Invalid StatusCode: '+ response;
-      e.statusCode = response.statusCode;
-      return callback(e);
+      if (response.statusCode == 404 && !meta.noError404) {
+        var e = new Error();
+        e.message = 'Invalid StatusCode: '+ response;
+        e.statusCode = response.statusCode;
+        return callback(e);
+      }
     }
     if (!meta._pool) response = err;
 
@@ -235,10 +237,14 @@ HttpRequest.prototype.handleRequestEnd = function(buffer) {
   
   // deal with errors
   if (this.meta.statusCode >= 400) {
-    var err = new Error();
-    err.message = buffer && buffer.toString().trim();
-    err.statusCode = this.meta.statusCode;
-    buffer = err;
+    if (this.meta.statusCode == 404 && this.meta.noError404) {
+      buffer = null;
+    } else {
+      var err = new Error();
+      err.message = buffer && buffer.toString().trim();
+      err.statusCode = this.meta.statusCode;
+      buffer = err;
+    }
   }
   
   if (this.meta.statusCode == 300 && this.meta.boundary) {


### PR DESCRIPTION
I think there might be a small issue with 404 handling in a pooled-connection setup. The 404 gets trapped in the `execute` function, and never reaches `handleError`, so `no404Error` directives are never processed.

This pull request proposes a fix, and also causes a 404 to return a null document instead of a hash of the error (which can be derived from the meta). This seems like a cleaner solution, since you can more easily check for null than for a 404 in the response.

Hopefully, I got this right. If not let me know :-)