### PR TITLE
Documentation meta fix

### DIFF
--- a/index.md
+++ b/index.md
@@ -317,22 +317,22 @@ These commands (`getFile`, `saveFile`, `removeFile`) behave much like their
 counterparts `get`, `save`, `remove`.  Except they don't take a `bucket`
 argument, internally reference the `luwak` raw resource, and always use
 `responseEncoding = 'binary'` therefore returning `Buffer`s.
-  
+
     db.getFile('lowcost-pilot')
-    
+
     db.saveFile('lowcost-pilot', buffer)
 
     db.removeFile('lowcost-pilot')
 
 #### Ping
 
-*Note: this command **only** takes an optional `callback`*
+*Note: this command _only_ takes an optional `callback`*
 
     db.ping()
 
 #### Stats
 
-*Note: this command **only** takes an optional `callback`*
+*Note: this command _only_ takes an optional `callback`*
 
     db.stats()
 


### PR DESCRIPTION
PR #155 introduced the issue that reusing the meta object from a previous request might send the wrong content-length. Since I think @mogadanez is right as stated in ISSUE #185 that just sending back all the headers might be a bad choice I suggest changing the documentation to reflect that. Comments?

And fix some rendering issues...
