### PR TITLE
Fix "Invalid Status Code: [object Object]" message

### DIFF
--- a/lib/http-request.js
+++ b/lib/http-request.js
@@ -67,7 +67,7 @@ HttpRequest.prototype.execute = function() {
     if (meta._pool && err) return callback(err);
     if (meta._pool && normalstatus.indexOf(response.statusCode) == -1) {
       var e = new Error();
-      e.message = 'Invalid StatusCode: '+ response;
+      e.message = 'Invalid StatusCode: '+ response.statusCode;
       e.statusCode = response.statusCode;
       return callback(e);
     }


### PR DESCRIPTION
Being unable to parse the response object (it being circular),
and judging from the rest of the message, pick up statusCode
of response object instead.
