### PR TITLE
parse index structure from response

### DIFF
--- a/lib/http-meta.js
+++ b/lib/http-meta.js
@@ -38,9 +38,15 @@ HttpMeta.prototype.loadResponse = function(response) {
     this.links = linkUtils.stringToLinks(response.client._httpMessage._headers.link);
   }
 
+  // 2ii
+  var indices = indexUtils.extract(headers);
+  if (indices) {
+    this.index = indices;
+  }
+
   // etag -- replace any quotes in the string
   if (headers.etag) this.etag = headers.etag.replace(/"/g, '');
-    
+
   // location
   if (headers.location) {
     var match = headers.location.match(/^\/([^\/]+)(?:\/([^\/]+))?\/([^\/]+)$/);
@@ -245,6 +251,49 @@ var _encodeUri = function(component, encodeUri) {
   component = component || '';
   if (!encodeUri) return component;
   return encodeURIComponent(component.replace(/\+/g, "%20"));
+}
+
+var indexUtils = {
+  Matcher: /x-riak-index-(.*)_(.*)/,
+
+  /**
+  * Parses indices from a response
+  * @param {Object} headers
+  * @return {Object} with indices in `Meta` representation.
+  * @api private
+  */
+  extract: function(headers) {
+    var rawIndices;
+    if (rawIndices = indexUtils.propsAndMatchesByRegex(indexUtils.Matcher, headers)) {
+      var indices = {};
+      rawIndices.forEach(function(index) {
+        var name = index.match[1];
+        var type = index.match[2];
+        var value = index.value;
+        if (type == "int") value = parseInt(value);
+        indices[name] = value;
+      })
+      return indices;
+    } else {
+      return false;
+    }
+  },
+
+  propsAndMatchesByRegex: function(r, obj) {
+    var m;
+    var key;
+    var res = [];
+    for (key in obj) {
+      if (m = r.exec(key)) {
+        res.push({ match: m, value: obj[key] });
+      }
+    }
+    if (res.length > 0) {
+      return res;
+    } else {
+      return false;
+    }
+  }
 }
 
 var linkUtils = {

--- a/test/http-client-test.js
+++ b/test/http-client-test.js
@@ -112,6 +112,20 @@ describe('http-client-tests', function() {
       });
   });
 
+  it('Fetching a document with 2ii', function(done) {
+    var index = { type: 'dude', number: 1 };
+    db.save(bucket, 'indexed_dude',
+      { name: 'Indexed Dude' },
+      { index: index },
+      function(_err, _data, _meta) {
+        db.get(bucket, 'indexed_dude', function(err, data, meta) {
+          should.exist(meta.index);
+          meta.index.should.eql(index);
+          done();
+        })
+      })
+  })
+
   it('Fetching a document with links', function(done) {
     db.get(bucket, 'other@gmail.com', function(err, data, meta) {
       should.not.exist(err);


### PR DESCRIPTION
add the indices to meta.index on get as they are defined when setting them via
`meta.index = { foo: 1, bar: "baz" }` on save.

FIXES #183
