### PR TITLE
Fix npm warning about repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,10 @@
       "url": "http://opensource.org/licenses/bsd-license.php"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "https://github.com/mostlyserious/riak-js.git"
-    }
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mostlyserious/riak-js.git"
+  },
   "main": "./lib/index",
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
repositories is not (no longer) valid package.json syntax it should be
repository, since the array only contains one element anyway it can just
be removed I would say. This stops npm from complaining about it.
