### PR TITLE
add support for `require("riak-js")()` to initialize a client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,30 +4,22 @@
 var HttpClient = require('./http-client'),
     ProtocolBuffersClient = require('./protocol-buffers-client');
 
-module.exports = {
-  
-  protobuf: function(options) {
-    return new ProtocolBuffersClient(options);
-  },
+module.exports = getClient;
 
-  http: function(options) {
-    return new HttpClient(options);
-  },
+function getClient(options) {
+  if (options == undefined) options = {};
 
-  /**
-   * Obtains an instance of `HttpClient`.
-   *
-   * @param {Object|Meta} options [optional]
-   * @return {HttpClient}
-   * @api public
-   */
-  getClient: function(options) {
-    if (options == undefined) options = {};
-
-    if (options.api == undefined) {
-      options.api = 'http';
-    }
-
-    return module.exports[options.api](options);
+  if (options.api == undefined) {
+    options.api = 'http';
   }
+
+  return getClient[options.api](options);
 }
+
+getClient.protobuf = function(options) {
+  return new ProtocolBuffersClient(options);
+};
+
+getClient.http = function(options) {
+  return new HttpClient(options);
+};


### PR DESCRIPTION
pretty common pattern these days:

``` js
var riak = require('riakj-js');
var db = riak({ host: 'n.n.n.n' });
```

leaves .getClient() and the others as-is
