### PR TITLE
Fixing riak.request.response

### DIFF
--- a/lib/http-request.js
+++ b/lib/http-request.js
@@ -10,7 +10,7 @@ var http = require('http'),
  * that can be used for instrumentation.
  *
  * - riak.request.start: Before the request is sent
- * - riak.request.request: When the response was received
+ * - riak.request.response: When the response was received
  * - riak.request.finish: When collecting request output finished
  * - riak.request.end: When processing the request ended
  *
@@ -73,6 +73,7 @@ HttpRequest.prototype.execute = function() {
     }
     if (!meta._pool) response = err;
 
+    self.event.response = response;
     self.client.emit('riak.request.response', self.event);
     var headers = response.headers,
       buffer = [],


### PR DESCRIPTION
Fixed 2 things:
- Comment about riak.request.response
- adding the actual response object to self.event so it can be used to instrument response sizes for example!
