### PR TITLE
fix mapreduce error message is [object object]

### DIFF
--- a/lib/http-request.js
+++ b/lib/http-request.js
@@ -236,7 +236,12 @@ HttpRequest.prototype.handleRequestEnd = function(buffer) {
   // deal with errors
   if (this.meta.statusCode >= 400) {
     var err = new Error();
-    err.message = buffer && buffer.toString().trim();
+    if(buffer === Object(buffer) && buffer.error){
+      err.message = buffer.error
+    }
+    else{
+      err.message = buffer && buffer.toString().trim();
+    }
     err.statusCode = this.meta.statusCode;
     buffer = err;
   }


### PR DESCRIPTION
Hi mostlyserious,

when I tried to use map reduce feature, I got error message like this "{ [Error: [object Object]] message: '[object Object]', statusCode: 500 }".
I change the code to check is buffer a object or not and try to leave the right error message.

Thanks.
