### PR TITLE
Method not allowed with node 0.12 and riak 1.3.2 (riak 1.4.12 too)

### DIFF
--- a/lib/http-request.js
+++ b/lib/http-request.js
@@ -60,7 +60,10 @@ HttpRequest.prototype.execute = function() {
 
   this.client.emit('riak.request.start', this.event)
 
-
+  var metarq = {};
+  for(var k in meta){
+    metarq[k] = meta[k];
+  }
 
   var request = httpClient.request(meta, function(err, response) {
     var normalstatus = [200,201,204,300,304];


### PR DESCRIPTION
Lib is fail on node 0.12 and riak 1.3.2 (riak 1.4.12 too)
On node 0.10 everything is ok
